### PR TITLE
Initial Design for Views

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -198,3 +198,12 @@ pub trait OutputRange: SemiOutputRange {
     /// O(1)
     fn at_mut(&mut self, i: &Self::Position) -> &mut Self::Element;
 }
+
+/// Marker trait for a view.
+///
+/// A view is also a range. However, unlike `Vec<T>`, view is intended for used
+/// as non-owning range i.e., it can be one of following:
+/// 1. refers to another range.
+/// 2. owns another view.
+/// 3. doesn't actually contains any element.
+pub trait View: InputRange {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,9 @@ pub mod core;
 pub mod rng;
 pub mod slice;
 pub mod vec;
+pub mod view;
 
 #[doc(inline)]
 pub use core::*;
+#[doc(inline)]
+pub use view::*;

--- a/src/view.rs
+++ b/src/view.rs
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024 Rishabh Dwivedi (rishabhdwivedi17@gmail.com)
+
+//! # Views module
+//!
+//! The `view` module provides collection of views over given range.
+//!
+//! A view is just a range that implements `View` marker trait.
+//!
+//! For obtaining view from a range use `.view()` or `.view_mut()` function.
+//!
+//! ```rust
+//! use stl::*;
+//!
+//! let arr = [1, 2, 3];
+//! let v = arr.view(); // An immutable view of arr.
+//!
+//! let mut arr = [1, 2, 3];
+//! let mut v = arr.view_mut(); // A mutable view of arr.
+//! ```
+
+use crate::{InputRange, SemiOutputRange};
+
+pub mod view_details {
+    use crate::{
+        BidirectionalRange, BoundedRange, ForwardRange, InputRange,
+        OutputRange, RandomAccessRange, SemiOutputRange, View,
+    };
+
+    pub struct RangeView<'a, Range: InputRange + ?Sized> {
+        pub range: &'a Range,
+    }
+
+    pub struct RangeMutView<'a, Range: InputRange + ?Sized> {
+        pub range: &'a mut Range,
+    }
+
+    impl<R> Clone for RangeView<'_, R>
+    where
+        R: InputRange + ?Sized,
+    {
+        fn clone(&self) -> Self {
+            Self { range: self.range }
+        }
+    }
+
+    impl<R> View for RangeView<'_, R> where R: InputRange + ?Sized {}
+    impl<R> View for RangeMutView<'_, R> where R: InputRange + ?Sized {}
+
+    impl<R> InputRange for RangeView<'_, R>
+    where
+        R: InputRange + ?Sized,
+    {
+        type Element = R::Element;
+
+        type Position = R::Position;
+
+        fn start(&self) -> Self::Position {
+            self.range.start()
+        }
+
+        fn is_end(&self, i: &Self::Position) -> bool {
+            self.range.is_end(i)
+        }
+
+        fn after(&self, i: Self::Position) -> Self::Position {
+            self.range.after(i)
+        }
+
+        fn at(&self, i: &Self::Position) -> &Self::Element {
+            self.range.at(i)
+        }
+
+        fn after_n(&self, i: Self::Position, n: usize) -> Self::Position {
+            self.range.after_n(i, n)
+        }
+    }
+
+    impl<R> InputRange for RangeMutView<'_, R>
+    where
+        R: InputRange + ?Sized,
+    {
+        type Element = R::Element;
+
+        type Position = R::Position;
+
+        fn start(&self) -> Self::Position {
+            self.range.start()
+        }
+
+        fn is_end(&self, i: &Self::Position) -> bool {
+            self.range.is_end(i)
+        }
+
+        fn after(&self, i: Self::Position) -> Self::Position {
+            self.range.after(i)
+        }
+
+        fn at(&self, i: &Self::Position) -> &Self::Element {
+            self.range.at(i)
+        }
+
+        fn after_n(&self, i: Self::Position, n: usize) -> Self::Position {
+            self.range.after_n(i, n)
+        }
+    }
+
+    impl<R> BoundedRange for RangeView<'_, R>
+    where
+        R: BoundedRange + ?Sized,
+    {
+        fn end(&self) -> Self::Position {
+            self.range.end()
+        }
+    }
+
+    impl<R> BoundedRange for RangeMutView<'_, R>
+    where
+        R: BoundedRange + ?Sized,
+    {
+        fn end(&self) -> Self::Position {
+            self.range.end()
+        }
+    }
+
+    impl<R> ForwardRange for RangeView<'_, R>
+    where
+        R: ForwardRange + ?Sized,
+    {
+        fn distance(&self, from: Self::Position, to: Self::Position) -> usize {
+            self.range.distance(from, to)
+        }
+    }
+
+    impl<R> ForwardRange for RangeMutView<'_, R>
+    where
+        R: ForwardRange + ?Sized,
+    {
+        fn distance(&self, from: Self::Position, to: Self::Position) -> usize {
+            self.range.distance(from, to)
+        }
+    }
+
+    impl<R> BidirectionalRange for RangeView<'_, R>
+    where
+        R: BidirectionalRange + ?Sized,
+    {
+        fn before(&self, i: Self::Position) -> Self::Position {
+            self.range.before(i)
+        }
+
+        fn before_n(&self, i: Self::Position, n: usize) -> Self::Position {
+            self.range.before_n(i, n)
+        }
+    }
+
+    impl<R> BidirectionalRange for RangeMutView<'_, R>
+    where
+        R: BidirectionalRange + ?Sized,
+    {
+        fn before(&self, i: Self::Position) -> Self::Position {
+            self.range.before(i)
+        }
+
+        fn before_n(&self, i: Self::Position, n: usize) -> Self::Position {
+            self.range.before_n(i, n)
+        }
+    }
+
+    impl<R> RandomAccessRange for RangeView<'_, R> where
+        R: RandomAccessRange + ?Sized
+    {
+    }
+    impl<R> RandomAccessRange for RangeMutView<'_, R> where
+        R: RandomAccessRange + ?Sized
+    {
+    }
+
+    impl<R> SemiOutputRange for RangeMutView<'_, R>
+    where
+        R: SemiOutputRange + ?Sized,
+    {
+        fn swap_at(&mut self, i: &Self::Position, j: &Self::Position) {
+            self.range.swap_at(i, j);
+        }
+    }
+
+    impl<R> OutputRange for RangeMutView<'_, R>
+    where
+        R: OutputRange + ?Sized,
+    {
+        fn at_mut(&mut self, i: &Self::Position) -> &mut Self::Element {
+            self.range.at_mut(i)
+        }
+    }
+}
+
+/// Provides `view` method for ranges.
+pub trait ViewExt: InputRange {
+    /// Returns view that immutably borrows from self.
+    fn view(&self) -> view_details::RangeView<Self> {
+        view_details::RangeView { range: self }
+    }
+}
+impl<R> ViewExt for R where R: InputRange + ?Sized {}
+
+/// Provides `view_mut` method for ranges.
+pub trait MutableViewExt: SemiOutputRange {
+    /// Returns view that mutably borrows from self.
+    fn view_mut(&mut self) -> view_details::RangeMutView<Self> {
+        view_details::RangeMutView { range: self }
+    }
+}
+
+impl<R> MutableViewExt for R where R: SemiOutputRange + ?Sized {}

--- a/src/view.rs
+++ b/src/view.rs
@@ -196,7 +196,7 @@ pub mod view_details {
 }
 
 /// Provides `view` method for ranges.
-pub trait ViewExt: InputRange {
+pub trait STLViewExt: InputRange {
     /// Returns view that immutably borrows from self.
     ///
     /// `Position` for the view would be same as `Position` type of self.
@@ -215,10 +215,10 @@ pub trait ViewExt: InputRange {
         view_details::RangeView { range: self }
     }
 }
-impl<R> ViewExt for R where R: InputRange + ?Sized {}
+impl<R> STLViewExt for R where R: InputRange + ?Sized {}
 
 /// Provides `view_mut` method for ranges.
-pub trait MutableViewExt: SemiOutputRange {
+pub trait STLMutableViewExt: SemiOutputRange {
     /// Returns view that mutably borrows from self.
     ///
     /// `Position` for the view would be same as `Position` type of self.
@@ -237,4 +237,4 @@ pub trait MutableViewExt: SemiOutputRange {
     }
 }
 
-impl<R> MutableViewExt for R where R: SemiOutputRange + ?Sized {}
+impl<R> STLMutableViewExt for R where R: SemiOutputRange + ?Sized {}

--- a/src/view.rs
+++ b/src/view.rs
@@ -31,7 +31,7 @@ pub mod view_details {
         pub range: &'a Range,
     }
 
-    pub struct RangeMutView<'a, Range: InputRange + ?Sized> {
+    pub struct RangeMutView<'a, Range: SemiOutputRange + ?Sized> {
         pub range: &'a mut Range,
     }
 
@@ -45,7 +45,7 @@ pub mod view_details {
     }
 
     impl<R> View for RangeView<'_, R> where R: InputRange + ?Sized {}
-    impl<R> View for RangeMutView<'_, R> where R: InputRange + ?Sized {}
+    impl<R> View for RangeMutView<'_, R> where R: SemiOutputRange + ?Sized {}
 
     impl<R> InputRange for RangeView<'_, R>
     where
@@ -78,7 +78,7 @@ pub mod view_details {
 
     impl<R> InputRange for RangeMutView<'_, R>
     where
-        R: InputRange + ?Sized,
+        R: SemiOutputRange + ?Sized,
     {
         type Element = R::Element;
 
@@ -116,7 +116,7 @@ pub mod view_details {
 
     impl<R> BoundedRange for RangeMutView<'_, R>
     where
-        R: BoundedRange + ?Sized,
+        R: BoundedRange + SemiOutputRange + ?Sized,
     {
         fn end(&self) -> Self::Position {
             self.range.end()
@@ -134,7 +134,7 @@ pub mod view_details {
 
     impl<R> ForwardRange for RangeMutView<'_, R>
     where
-        R: ForwardRange + ?Sized,
+        R: SemiOutputRange + ?Sized,
     {
         fn distance(&self, from: Self::Position, to: Self::Position) -> usize {
             self.range.distance(from, to)
@@ -156,7 +156,7 @@ pub mod view_details {
 
     impl<R> BidirectionalRange for RangeMutView<'_, R>
     where
-        R: BidirectionalRange + ?Sized,
+        R: BidirectionalRange + SemiOutputRange + ?Sized,
     {
         fn before(&self, i: Self::Position) -> Self::Position {
             self.range.before(i)
@@ -172,7 +172,7 @@ pub mod view_details {
     {
     }
     impl<R> RandomAccessRange for RangeMutView<'_, R> where
-        R: RandomAccessRange + ?Sized
+        R: RandomAccessRange + SemiOutputRange + ?Sized
     {
     }
 
@@ -198,6 +198,19 @@ pub mod view_details {
 /// Provides `view` method for ranges.
 pub trait ViewExt: InputRange {
     /// Returns view that immutably borrows from self.
+    ///
+    /// `Position` for the view would be same as `Position` type of self.
+    ///
+    /// # Example
+    /// ```rust
+    /// use stl::*;
+    /// use rng::infix::*;
+    ///
+    /// let mut sum = 0;
+    /// let arr = [1, 2, 3];
+    /// arr.view().for_each(|x| sum += x);
+    /// assert_eq!(sum, 6);
+    /// ```
     fn view(&self) -> view_details::RangeView<Self> {
         view_details::RangeView { range: self }
     }
@@ -207,6 +220,18 @@ impl<R> ViewExt for R where R: InputRange + ?Sized {}
 /// Provides `view_mut` method for ranges.
 pub trait MutableViewExt: SemiOutputRange {
     /// Returns view that mutably borrows from self.
+    ///
+    /// `Position` for the view would be same as `Position` type of self.
+    ///
+    /// # Example
+    /// ```rust
+    /// use stl::*;
+    /// use rng::infix::*;
+    ///
+    /// let mut arr = [2, 1, 3];
+    /// arr.view_mut().sort_range();
+    /// assert_eq!(arr, [1, 2, 3]);
+    /// ```
     fn view_mut(&mut self) -> view_details::RangeMutView<Self> {
         view_details::RangeMutView { range: self }
     }

--- a/tests/view_test.rs
+++ b/tests/view_test.rs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024 Rishabh Dwivedi (rishabhdwivedi17@gmail.com)
+
+#[cfg(test)]
+pub mod tests {
+    use rng::infix::*;
+    use stl::*;
+
+    #[test]
+    fn view_acts_as_range() {
+        let mut sum = 0;
+        let arr = [1, 2, 3];
+        arr.view().for_each(|x| sum += x);
+        assert_eq!(sum, 6);
+    }
+
+    #[test]
+    fn mutable_view_acts_as_range() {
+        let mut arr = [3, 2, 1];
+        arr.view_mut().sort_range();
+        assert_eq!(arr, [1, 2, 3])
+    }
+}


### PR DESCRIPTION
# Description
Views are really helpful for lazy operation on ranges. It is similar to what Rust iterators allows us to do or haskell lists allows us to do. Views are described as non-owning ranges, i.e., a view would never own the data and some other container may own the data.

## How we support view
We expose a marker trait named `View` that a struct needs to implement to be treated as a View. A View is an extension of InputRange that means, any struct implementing View should be atleast an InputRange.

## Scope of PR
[x] Should be able to construct views from ranges
[x] Should be able to use ranges as views

## How it looks
```rust
        let mut sum = 0;
        let arr = [1, 2, 3];
        arr.view().for_each(|x| sum += x);
        assert_eq!(sum, 6);
```

```rust
        let mut arr = [3, 2, 1];
        arr.view_mut().sort_range();
        assert_eq!(arr, [1, 2, 3])
```