### PR TITLE
Introduce ElementRef<'a> and ElementMutRef<'a> for supporting view adaptors

### DIFF
--- a/src/algo/adjacent_find.rs
+++ b/src/algo/adjacent_find.rs
@@ -41,7 +41,7 @@ where
     let mut prev = start.clone();
     start = rng.after(start);
     while start != end {
-        if bi_pred(rng.at(&prev), rng.at(&start)) {
+        if bi_pred(&rng.at(&prev), &rng.at(&start)) {
             return prev;
         }
         prev = start.clone();

--- a/src/algo/binary_search.rs
+++ b/src/algo/binary_search.rs
@@ -271,7 +271,7 @@ where
     Compare: Fn(&Range::Element, &Range::Element) -> bool + Clone,
 {
     let i = lower_bound_by(rng, start, end.clone(), ele, is_less.clone());
-    i != end && !is_less(ele, rng.at(&i))
+    i != end && !is_less(ele, &rng.at(&i))
 }
 
 /// Checks if element equal to `ele` wrt comparator appears within range.

--- a/src/algo/copy.rs
+++ b/src/algo/copy.rs
@@ -44,7 +44,7 @@ where
     Pred: Fn(&SrcRange::Element) -> bool,
 {
     while start != end {
-        if pred(src.at(&start)) {
+        if pred(&src.at(&start)) {
             *dest.at_mut(&out) = src.at(&start).clone();
             out = dest.after(out);
         }

--- a/src/algo/count.rs
+++ b/src/algo/count.rs
@@ -33,7 +33,7 @@ where
 {
     let mut cnt: u32 = 0;
     while start != end {
-        if pred(rng.at(&start)) {
+        if pred(&rng.at(&start)) {
             cnt += 1;
         }
         start = rng.after(start);

--- a/src/algo/equals.rs
+++ b/src/algo/equals.rs
@@ -44,7 +44,7 @@ where
     BinaryPred: Fn(&R1::Element, &R2::Element) -> bool,
 {
     while start1 != end1 && start2 != end2 {
-        if !bi_pred(rng1.at(&start1), rng2.at(&start2)) {
+        if !bi_pred(&rng1.at(&start1), &rng2.at(&start2)) {
             return false;
         }
         start1 = rng1.after(start1);
@@ -135,7 +135,7 @@ where
     F: Fn(&R1::Element, &R2::Element) -> bool,
 {
     while start1 != end1 && start2 != end2 {
-        if !bi_pred(rng1.at(&start1), rng2.at(&start2)) {
+        if !bi_pred(&rng1.at(&start1), &rng2.at(&start2)) {
             return false;
         }
         start1 = rng1.after(start1);

--- a/src/algo/find.rs
+++ b/src/algo/find.rs
@@ -33,7 +33,7 @@ where
     Pred: Fn(&Range::Element) -> bool,
 {
     while start != end {
-        if pred(rng.at(&start)) {
+        if pred(&rng.at(&start)) {
             break;
         }
         start = rng.after(start)

--- a/src/algo/for_each.rs
+++ b/src/algo/for_each.rs
@@ -33,7 +33,7 @@ pub fn for_each<Range, UnaryOp>(
     UnaryOp: FnMut(&Range::Element),
 {
     while start != end {
-        op(rng.at(&start));
+        op(&rng.at(&start));
         start = rng.after(start);
     }
 }
@@ -69,7 +69,7 @@ pub fn for_each_mut<Range, UnaryOp>(
     UnaryOp: FnMut(&mut Range::Element),
 {
     while start != end {
-        op(rng.at_mut(&start));
+        op(&mut rng.at_mut(&start));
         start = rng.after(start);
     }
 }

--- a/src/algo/heap.rs
+++ b/src/algo/heap.rs
@@ -37,7 +37,7 @@ where
     for son in 1..n {
         let son_pos = rng.after_n(start.clone(), son);
         let dad_pos = rng.after_n(start.clone(), dad);
-        if is_less(rng.at(&dad_pos), rng.at(&son_pos)) {
+        if is_less(&rng.at(&dad_pos), &rng.at(&son_pos)) {
             return son_pos;
         } else if son % 2 == 0 {
             dad += 1;
@@ -184,7 +184,7 @@ pub fn push_heap_by<Range, Compare>(
         let parent = (cur - 1) >> 1;
         let parent_pos = rng.after_n(start.clone(), parent);
         let cur_pos = rng.after_n(start.clone(), cur);
-        if is_less(rng.at(&parent_pos), rng.at(&cur_pos)) {
+        if is_less(&rng.at(&parent_pos), &rng.at(&cur_pos)) {
             rng.swap_at(&parent_pos, &cur_pos);
             cur = parent;
         } else {
@@ -506,14 +506,14 @@ pub mod heap_details {
 
             if left_child < n {
                 let left_pos = rng.after_n(start.clone(), left_child);
-                if is_less(rng.at(&largest), rng.at(&left_pos)) {
+                if is_less(&rng.at(&largest), &rng.at(&left_pos)) {
                     largest = left_pos;
                 }
             }
 
             if right_child < n {
                 let right_pos = rng.after_n(start.clone(), right_child);
-                if is_less(rng.at(&largest), rng.at(&right_pos)) {
+                if is_less(&rng.at(&largest), &rng.at(&right_pos)) {
                     largest = right_pos;
                 }
             }
@@ -540,7 +540,7 @@ pub mod heap_details {
         make_heap_by(rng, start.clone(), mid.clone(), is_less.clone());
         let mut cur = mid.clone();
         while cur != end {
-            if is_less(rng.at(&cur), rng.at(&start)) {
+            if is_less(&rng.at(&cur), &rng.at(&start)) {
                 rng.swap_at(&cur, &start);
                 heapify(rng, start.clone(), mid.clone(), is_less.clone());
             }
@@ -573,7 +573,7 @@ pub mod heap_details {
 
         make_heap_by(dest, dest_start.clone(), write.clone(), is_less.clone());
         while !src_till(&src_start) {
-            if is_less(src.at(&src_start), dest.at(&dest_start)) {
+            if is_less(&src.at(&src_start), &dest.at(&dest_start)) {
                 *dest.at_mut(&dest_start) = src.at(&src_start).clone();
                 heapify(
                     dest,

--- a/src/algo/merge.rs
+++ b/src/algo/merge.rs
@@ -175,14 +175,27 @@ fn merge_inplace_by_left_buffer<Range, Compare, Buffer>(
 
     while left_pos != left_end && right_pos != right_end {
         unsafe {
-            let left_elem = buf.at_mut(&left_pos).assume_init_mut();
-            let right_elem = rng.at(&right_pos);
+            let l = {
+                let left_raw_elem =
+                    (&mut (buf.at_mut(&left_pos))) as &mut Buffer::Element;
+                let left_elem = left_raw_elem.assume_init_mut();
+                let right_elem = &rng.at(&right_pos) as &Range::Element;
+                is_less(right_elem, left_elem)
+            };
 
-            if is_less(right_elem, left_elem) {
+            if l {
                 rng.swap_at(&merge, &right_pos);
                 right_pos = rng.after(right_pos);
             } else {
-                std::mem::swap(rng.at_mut(&merge), left_elem);
+                {
+                    let left_raw_elem =
+                        (&mut (buf.at_mut(&left_pos))) as &mut Buffer::Element;
+                    let left_elem = left_raw_elem.assume_init_mut();
+                    std::mem::swap(
+                        &mut rng.at_mut(&merge) as &mut Range::Element,
+                        left_elem,
+                    );
+                };
                 left_pos = buf.after(left_pos);
             }
         }
@@ -241,13 +254,27 @@ fn merge_inplace_by_right_buffer<Range, Compare, Buffer>(
 
     while left_pos != left_start && right_pos != right_start {
         unsafe {
-            let left_elem = rng.at(&rng.before(left_pos.clone()));
-            let right_elem =
-                buf.at_mut(&buf.before(right_pos.clone())).assume_init_mut();
+            let l = {
+                let left_elem =
+                    &rng.at(&rng.before(left_pos.clone())) as &Range::Element;
+                let right_elem_raw =
+                    (&mut (buf.at_mut(&right_pos))) as &mut Buffer::Element;
+                let right_elem = right_elem_raw.assume_init_mut();
 
-            if !is_less(right_elem, left_elem) {
+                !is_less(right_elem, left_elem)
+            };
+
+            if l {
                 merge = rng.before(merge);
-                std::mem::swap(rng.at_mut(&merge), right_elem);
+                {
+                    let right_elem_raw =
+                        (&mut (buf.at_mut(&right_pos))) as &mut Buffer::Element;
+                    let right_elem = right_elem_raw.assume_init_mut();
+                    std::mem::swap(
+                        &mut rng.at_mut(&merge) as &mut Range::Element,
+                        right_elem,
+                    );
+                };
                 right_pos = buf.before(right_pos);
             } else {
                 merge = rng.before(merge);

--- a/src/algo/merge.rs
+++ b/src/algo/merge.rs
@@ -224,7 +224,9 @@ fn merge_inplace_by_right_buffer<Range, Compare, Buffer>(
         let mut j = buf.start();
         while i != end {
             unsafe {
-                *buf.at_mut(&j) = MaybeUninit::new(std::ptr::read(rng.at(&i)));
+                *buf.at_mut(&j) = MaybeUninit::new(std::ptr::read(
+                    (&rng.at(&i)) as &Range::Element,
+                ));
             }
             i = rng.after(i);
             j = buf.after(j);

--- a/src/algo/merge.rs
+++ b/src/algo/merge.rs
@@ -192,7 +192,7 @@ fn merge_inplace_by_left_buffer<Range, Compare, Buffer>(
     while left_pos != left_end {
         unsafe {
             std::mem::swap(
-                rng.at_mut(&merge),
+                &mut rng.at_mut(&merge) as &mut Range::Element,
                 buf.at_mut(&left_pos).assume_init_mut(),
             );
         }
@@ -262,7 +262,7 @@ fn merge_inplace_by_right_buffer<Range, Compare, Buffer>(
         merge = rng.before(merge);
         unsafe {
             std::mem::swap(
-                rng.at_mut(&merge),
+                &mut rng.at_mut(&merge) as &mut Range::Element,
                 buf.at_mut(&right_pos).assume_init_mut(),
             );
         }

--- a/src/algo/merge.rs
+++ b/src/algo/merge.rs
@@ -257,8 +257,9 @@ fn merge_inplace_by_right_buffer<Range, Compare, Buffer>(
             let l = {
                 let left_elem =
                     &rng.at(&rng.before(left_pos.clone())) as &Range::Element;
-                let right_elem_raw =
-                    (&mut (buf.at_mut(&right_pos))) as &mut Buffer::Element;
+                let right_elem_raw = (&mut (buf
+                    .at_mut(&buf.before(right_pos.clone()))))
+                    as &mut Buffer::Element;
                 let right_elem = right_elem_raw.assume_init_mut();
 
                 !is_less(right_elem, left_elem)
@@ -267,8 +268,9 @@ fn merge_inplace_by_right_buffer<Range, Compare, Buffer>(
             if l {
                 merge = rng.before(merge);
                 {
-                    let right_elem_raw =
-                        (&mut (buf.at_mut(&right_pos))) as &mut Buffer::Element;
+                    let right_elem_raw = (&mut (buf
+                        .at_mut(&buf.before(right_pos.clone()))))
+                        as &mut Buffer::Element;
                     let right_elem = right_elem_raw.assume_init_mut();
                     std::mem::swap(
                         &mut rng.at_mut(&merge) as &mut Range::Element,

--- a/src/algo/merge.rs
+++ b/src/algo/merge.rs
@@ -68,7 +68,7 @@ where
         if start2 == end2 {
             return copy(rng1, start1, end1, dest, out);
         }
-        if is_less(rng2.at(&start2), rng1.at(&start1)) {
+        if is_less(&rng2.at(&start2), &rng1.at(&start1)) {
             *dest.at_mut(&out) = rng2.at(&start2).clone();
             start2 = rng2.after(start2);
         } else {
@@ -158,7 +158,9 @@ fn merge_inplace_by_left_buffer<Range, Compare, Buffer>(
         let mut j = buf.start();
         while i != mid {
             unsafe {
-                *buf.at_mut(&j) = MaybeUninit::new(std::ptr::read(rng.at(&i)));
+                *buf.at_mut(&j) = MaybeUninit::new(std::ptr::read(
+                    &rng.at(&i) as &Range::Element
+                ));
             }
             i = rng.after(i);
             j = buf.after(j);
@@ -432,7 +434,7 @@ pub fn merge_inplace_by_no_alloc<Range, Compare>(
             rng,
             mid.clone(),
             end.clone(),
-            rng.at(&left_half),
+            &rng.at(&left_half),
             is_less.clone(),
         );
         let mut right_start =
@@ -447,7 +449,7 @@ pub fn merge_inplace_by_no_alloc<Range, Compare>(
             rng,
             start.clone(),
             mid.clone(),
-            rng.at(&right_half),
+            &rng.at(&right_half),
             is_less.clone(),
         );
         let left_end = rng.after_n(left_half.clone(), half);

--- a/src/algo/minmax.rs
+++ b/src/algo/minmax.rs
@@ -45,7 +45,7 @@ where
     start = rng.after(start);
 
     while start != end {
-        if is_less(rng.at(&start), rng.at(&smallest)) {
+        if is_less(&rng.at(&start), &rng.at(&smallest)) {
             smallest = start.clone();
         }
         start = rng.after(start);
@@ -130,7 +130,7 @@ where
     start = rng.after(start);
 
     while start != end {
-        if !is_less(rng.at(&start), rng.at(&max)) {
+        if !is_less(&rng.at(&start), &rng.at(&max)) {
             max = start.clone();
         }
         start = rng.after(start);
@@ -223,7 +223,7 @@ where
         return (min, max);
     }
 
-    if is_less(rng.at(&start), rng.at(&min)) {
+    if is_less(&rng.at(&start), &rng.at(&min)) {
         min = start.clone();
     } else {
         max = start.clone();
@@ -235,24 +235,24 @@ where
         let i = start.clone();
         start = rng.after(start);
         if start == end {
-            if is_less(rng.at(&i), rng.at(&min)) {
+            if is_less(&rng.at(&i), &rng.at(&min)) {
                 min = i;
-            } else if !is_less(rng.at(&i), rng.at(&max)) {
+            } else if !is_less(&rng.at(&i), &rng.at(&max)) {
                 max = i;
             }
             break;
-        } else if is_less(rng.at(&start), rng.at(&i)) {
-            if is_less(rng.at(&start), rng.at(&min)) {
+        } else if is_less(&rng.at(&start), &rng.at(&i)) {
+            if is_less(&rng.at(&start), &rng.at(&min)) {
                 min = start.clone();
             }
-            if !is_less(rng.at(&i), rng.at(&max)) {
+            if !is_less(&rng.at(&i), &rng.at(&max)) {
                 max = i;
             }
         } else {
-            if is_less(rng.at(&i), rng.at(&min)) {
+            if is_less(&rng.at(&i), &rng.at(&min)) {
                 min = i;
             }
-            if !is_less(rng.at(&start), rng.at(&max)) {
+            if !is_less(&rng.at(&start), &rng.at(&max)) {
                 max = start.clone();
             }
         }

--- a/src/algo/mismatch.rs
+++ b/src/algo/mismatch.rs
@@ -31,7 +31,7 @@ where
     BinaryPred: Fn(&R1::Element, &R2::Element) -> bool,
 {
     while start1 != end1 {
-        if !bi_pred(rng1.at(&start1), rng2.at(&start2)) {
+        if !bi_pred(&rng1.at(&start1), &rng2.at(&start2)) {
             return (start1, start2);
         }
         start1 = rng1.after(start1);
@@ -111,7 +111,7 @@ where
     BinaryPred: Fn(&R1::Element, &R2::Element) -> bool,
 {
     while start1 != end1 && start2 != end2 {
-        if !bi_pred(rng1.at(&start1), rng2.at(&start2)) {
+        if !bi_pred(&rng1.at(&start1), &rng2.at(&start2)) {
             return (start1, start2);
         }
         start1 = rng1.after(start1);

--- a/src/algo/numeric.rs
+++ b/src/algo/numeric.rs
@@ -39,7 +39,7 @@ where
     BinaryOp: Fn(Result, &Range::Element) -> Result,
 {
     while start != end {
-        init = op(init, rng.at(&start));
+        init = op(init, &rng.at(&start));
         start = rng.after(start);
     }
     init
@@ -82,7 +82,7 @@ where
 {
     while start != end {
         end = rng.before(end);
-        init = op(rng.at(&end), init);
+        init = op(&rng.at(&end), init);
     }
     init
 }

--- a/src/algo/of.rs
+++ b/src/algo/of.rs
@@ -33,7 +33,7 @@ where
     Pred: Fn(&Range::Element) -> bool,
 {
     while start != end {
-        if !pred(rng.at(&start)) {
+        if !pred(&rng.at(&start)) {
             return false;
         }
         start = rng.after(start);
@@ -71,7 +71,7 @@ where
     Pred: Fn(&Range::Element) -> bool,
 {
     while start != end {
-        if pred(rng.at(&start)) {
+        if pred(&rng.at(&start)) {
             return true;
         }
         start = rng.after(start);
@@ -109,7 +109,7 @@ where
     Pred: Fn(&Range::Element) -> bool,
 {
     while start != end {
-        if pred(rng.at(&start)) {
+        if pred(&rng.at(&start)) {
             return false;
         }
         start = rng.after(start);

--- a/src/algo/partition.rs
+++ b/src/algo/partition.rs
@@ -343,7 +343,7 @@ pub mod partition_details {
         while buf_cur != buf_write {
             unsafe {
                 std::mem::swap(
-                    rng.at_mut(&rng_write),
+                    (&mut rng.at_mut(&rng_write)) as &mut Range::Element,
                     buf.at_mut(&buf_cur).assume_init_mut(),
                 );
             }

--- a/src/algo/partition.rs
+++ b/src/algo/partition.rs
@@ -36,14 +36,14 @@ where
     Predicate: Fn(&Range::Element) -> bool,
 {
     while start != end {
-        if !pred(rng.at(&start)) {
+        if !pred(&rng.at(&start)) {
             break;
         }
         start = rng.after(start);
     }
 
     while start != end {
-        if pred(rng.at(&start)) {
+        if pred(&rng.at(&start)) {
             return false;
         }
         start = rng.after(start);
@@ -89,7 +89,7 @@ where
     Range: SemiOutputRange + ?Sized,
     Predicate: Fn(&Range::Element) -> bool,
 {
-    partition_details::partition_pos(rng, start, end, |r, i| pred(r.at(i)))
+    partition_details::partition_pos(rng, start, end, |r, i| pred(&r.at(i)))
 }
 
 /// Partitions range based on given predicate with preserving relative order of elements.
@@ -138,7 +138,7 @@ where
     Predicate: Fn(&Range::Element) -> bool + Clone,
 {
     partition_details::stable_partition_pos(rng, start, end, |r, i| {
-        pred(r.at(i))
+        pred(&r.at(i))
     })
 }
 
@@ -185,7 +185,7 @@ where
     Predicate: Fn(&Range::Element) -> bool + Clone,
 {
     partition_details::stable_partition_no_alloc_pos(rng, start, end, |r, i| {
-        pred(r.at(i))
+        pred(&r.at(i))
     })
 }
 
@@ -227,7 +227,7 @@ where
     while n > 0 {
         let half = n / 2;
         let mid = rng.after_n(start.clone(), half);
-        if pred(rng.at(&mid)) {
+        if pred(&rng.at(&mid)) {
             start = rng.after(mid);
             n -= half + 1;
         } else {
@@ -328,8 +328,9 @@ pub mod partition_details {
                 }
             } else {
                 unsafe {
-                    *buf.at_mut(&buf_write) =
-                        MaybeUninit::new(std::ptr::read(rng.at(&start)));
+                    *buf.at_mut(&buf_write) = MaybeUninit::new(std::ptr::read(
+                        &rng.at(&start) as &Range::Element,
+                    ));
                 }
                 buf_write = buf.after(buf_write);
             }

--- a/src/algo/remove.rs
+++ b/src/algo/remove.rs
@@ -41,7 +41,7 @@ where
     Pred: Fn(&Range::Element) -> bool,
 {
     while start != end {
-        if pred(rng.at(&start)) {
+        if pred(&rng.at(&start)) {
             break;
         }
         start = rng.after(start);
@@ -49,7 +49,7 @@ where
     if start != end {
         let mut i = rng.after(start.clone());
         while i != end {
-            if !pred(rng.at(&i)) {
+            if !pred(&rng.at(&i)) {
                 rng.swap_at(&i, &start);
                 start = rng.after(start);
             }
@@ -142,7 +142,7 @@ where
     Pred: Fn(&SrcRange::Element) -> bool,
 {
     while start != end {
-        if !pred(src.at(&start)) {
+        if !pred(&src.at(&start)) {
             *dest.at_mut(&out) = src.at(&start).clone();
             out = dest.after(out);
         }

--- a/src/algo/replace.rs
+++ b/src/algo/replace.rs
@@ -38,7 +38,7 @@ pub fn replace_if<Range, Pred>(
     Pred: Fn(&Range::Element) -> bool,
 {
     while start != end {
-        if pred(rng.at(&start)) {
+        if pred(&rng.at(&start)) {
             *rng.at_mut(&start) = new_e.clone();
         }
         start = rng.after(start);
@@ -122,7 +122,7 @@ where
     Pred: Fn(&SrcRange::Element) -> bool,
 {
     while start != end {
-        if pred(src.at(&start)) {
+        if pred(&src.at(&start)) {
             *dest.at_mut(&out) = new_e.clone();
         } else {
             *dest.at_mut(&out) = src.at(&start).clone();

--- a/src/algo/sort.rs
+++ b/src/algo/sort.rs
@@ -348,7 +348,7 @@ where
     let mut prev = start.clone();
     start = rng.after(start);
     while start != end {
-        if is_less(rng.at(&start), rng.at(&prev)) {
+        if is_less(&rng.at(&start), &rng.at(&prev)) {
             return start;
         }
         prev = start.clone();
@@ -711,7 +711,7 @@ pub fn nth_element_by<Range, Compare>(
         rng.swap_at(&pivot, &last_ele_pos);
         pivot =
             partition_pos(rng, start.clone(), last_ele_pos.clone(), |r, i| {
-                is_less(r.at(i), r.at(&last_ele_pos))
+                is_less(&r.at(i), &r.at(&last_ele_pos))
             });
         rng.swap_at(&pivot, &last_ele_pos);
 
@@ -794,7 +794,7 @@ pub mod sort_details {
         while i != end {
             let mut j = i.clone();
             while j != start
-                && is_less(rng.at(&j), rng.at(&rng.before(j.clone())))
+                && is_less(&rng.at(&j), &rng.at(&rng.before(j.clone())))
             {
                 let prev = rng.before(j.clone());
                 rng.swap_at(&prev, &j);
@@ -827,7 +827,7 @@ pub mod sort_details {
         let partition_start = rng.after(pivot.clone());
         let partition_point =
             partition_pos(rng, partition_start, end.clone(), |r, i| {
-                is_less(r.at(i), r.at(&pivot))
+                is_less(&r.at(i), &r.at(&pivot))
             });
         let left_end = rng.before(partition_point.clone());
         rng.swap_at(&pivot, &left_end);
@@ -908,7 +908,7 @@ pub mod sort_details {
             rng,
             partition_start.clone(),
             end.clone(),
-            |r, i| is_less(r.at(i), r.at(&pivot)),
+            |r, i| is_less(&r.at(i), &r.at(&pivot)),
         );
         let left_end = rng.before(partition_point.clone());
         rotate(rng, pivot, partition_start, partition_point.clone());
@@ -976,7 +976,7 @@ pub mod sort_details {
             rng,
             partition_start.clone(),
             end.clone(),
-            |r, i| is_less(r.at(i), r.at(&pivot)),
+            |r, i| is_less(&r.at(i), &r.at(&pivot)),
         );
 
         let left_end = rng.before(partition_point.clone());

--- a/src/algo/swap_ranges.rs
+++ b/src/algo/swap_ranges.rs
@@ -48,7 +48,10 @@ where
     R2: OutputRange<Element = R1::Element> + ?Sized,
 {
     while start1 != end1 && start2 != end2 {
-        std::mem::swap(rng1.at_mut(&start1), rng2.at_mut(&start2));
+        std::mem::swap(
+            (&mut rng1.at_mut(&start1)) as &mut R1::Element,
+            (&mut rng2.at_mut(&start2)) as &mut R2::Element,
+        );
         start1 = rng1.after(start1);
         start2 = rng2.after(start2);
     }

--- a/src/algo/transform.rs
+++ b/src/algo/transform.rs
@@ -42,7 +42,7 @@ where
     UnaryOp: Fn(&SrcRange::Element) -> DestRange::Element,
 {
     while start != end {
-        *dest.at_mut(&out) = unary_op(src.at(&start));
+        *dest.at_mut(&out) = unary_op(&src.at(&start));
         start = src.after(start);
         out = dest.after(out);
     }
@@ -93,7 +93,7 @@ where
     BinaryOp: Fn(&R1::Element, &R2::Element) -> DestRange::Element,
 {
     while start1 != end1 {
-        *dest.at_mut(&out) = binary_op(rng1.at(&start1), rng2.at(&start2));
+        *dest.at_mut(&out) = binary_op(&rng1.at(&start1), &rng2.at(&start2));
         start1 = rng1.after(start1);
         start2 = rng2.after(start2);
         out = dest.after(out);

--- a/src/algo/unique.rs
+++ b/src/algo/unique.rs
@@ -48,7 +48,7 @@ where
     let mut result = start.clone();
     start = rng.after(start);
     while start != end {
-        if !bi_pred(rng.at(&result), rng.at(&start)) {
+        if !bi_pred(&rng.at(&result), &rng.at(&start)) {
             result = rng.after(result);
             if result != start {
                 rng.swap_at(&result, &start);
@@ -145,7 +145,7 @@ where
     *dest.at_mut(&out) = src.at(&start).clone();
     start = src.after(start);
     while start != end {
-        if !bi_pred(dest.at(&out), src.at(&start)) {
+        if !bi_pred(&dest.at(&out), &src.at(&start)) {
             out = dest.after(out);
             *dest.at_mut(&out) = src.at(&start).clone();
         }

--- a/src/array.rs
+++ b/src/array.rs
@@ -70,7 +70,12 @@ impl<T, const N: usize> SemiOutputRange for [T; N] {
 }
 
 impl<T, const N: usize> OutputRange for [T; N] {
-    fn at_mut(&mut self, i: &Self::Position) -> &mut Self::Element {
+    type ElementMutRef<'a>
+        = &'a mut T
+    where
+        Self: 'a;
+
+    fn at_mut<'a>(&'a mut self, i: &Self::Position) -> Self::ElementMutRef<'a> {
         &mut self[*i]
     }
 }

--- a/src/array.rs
+++ b/src/array.rs
@@ -11,6 +11,11 @@ use crate::{
 impl<T, const N: usize> InputRange for [T; N] {
     type Element = T;
 
+    type ElementRef<'a>
+        = &'a T
+    where
+        Self: 'a;
+
     type Position = usize;
 
     fn start(&self) -> Self::Position {
@@ -25,7 +30,7 @@ impl<T, const N: usize> InputRange for [T; N] {
         i + n
     }
 
-    fn at(&self, i: &Self::Position) -> &Self::Element {
+    fn at<'a>(&'a self, i: &Self::Position) -> Self::ElementRef<'a> {
         &self[*i]
     }
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -43,7 +43,7 @@ pub trait InputRange {
     /// Type of reference to element.
     ///
     /// Very useful in scenarios when range actually doesn't contain the elements
-    /// and proxy reference is necessary
+    /// and proxy reference is necessary.
     type ElementRef<'a>: std::ops::Deref<Target = Self::Element>
     where
         Self: 'a;
@@ -197,6 +197,14 @@ pub trait SemiOutputRange: ForwardRange {
 ///    For the same, `at_mut` function is required that returns mutable
 ///    reference to element at any position.
 pub trait OutputRange: SemiOutputRange {
+    /// Type of mutable reference to element.
+    ///
+    /// Very useful in scenarios when range actually doesn't contain the elements
+    /// and proxy mutable reference is necessary.
+    type ElementMutRef<'a>: std::ops::DerefMut<Target = Self::Element>
+    where
+        Self: 'a;
+
     /// Access element at position i
     ///
     /// # Precondition
@@ -204,7 +212,7 @@ pub trait OutputRange: SemiOutputRange {
     ///
     /// # Complexity Requirement
     /// O(1)
-    fn at_mut(&mut self, i: &Self::Position) -> &mut Self::Element;
+    fn at_mut<'a>(&'a mut self, i: &Self::Position) -> Self::ElementMutRef<'a>;
 }
 
 /// Marker trait for a view.

--- a/src/core.rs
+++ b/src/core.rs
@@ -40,6 +40,14 @@ pub trait InputRange {
     /// Type of the positions in self
     type Position: SemiRegular;
 
+    /// Type of reference to element.
+    ///
+    /// Very useful in scenarios when range actually doesn't contain the elements
+    /// and proxy reference is necessary
+    type ElementRef<'a>: std::ops::Deref<Target = Self::Element>
+    where
+        Self: 'a;
+
     /// Returns the position of first element in self,
     /// or if self is empty then start() == end()
     fn start(&self) -> Self::Position;
@@ -75,7 +83,7 @@ pub trait InputRange {
     ///
     /// # Complexity Requirement
     /// O(1)
-    fn at(&self, i: &Self::Position) -> &Self::Element;
+    fn at<'a>(&'a self, i: &Self::Position) -> Self::ElementRef<'a>;
 }
 
 /// Models a bounded range, i.e., the range whose end position is known.

--- a/src/rng/adjacent_find.rs
+++ b/src/rng/adjacent_find.rs
@@ -45,7 +45,7 @@ where
     let mut prev = start.clone();
     start = rng.after(start);
     while !rng.is_end(&start) {
-        if bi_pred(rng.at(&prev), rng.at(&start)) {
+        if bi_pred(&rng.at(&prev), &rng.at(&start)) {
             return prev;
         }
         prev = start.clone();

--- a/src/rng/copy.rs
+++ b/src/rng/copy.rs
@@ -50,7 +50,7 @@ where
     let mut start = src.start();
     let mut write = dest.start();
     while !src.is_end(&start) && !dest.is_end(&write) {
-        if pred(src.at(&start)) {
+        if pred(&src.at(&start)) {
             *dest.at_mut(&write) = src.at(&start).clone();
             write = dest.after(write);
         }

--- a/src/rng/count.rs
+++ b/src/rng/count.rs
@@ -36,7 +36,7 @@ where
     let mut start = rng.start();
     let mut cnt: u32 = 0;
     while !rng.is_end(&start) {
-        if pred(rng.at(&start)) {
+        if pred(&rng.at(&start)) {
             cnt += 1;
         }
         start = rng.after(start);

--- a/src/rng/equals.rs
+++ b/src/rng/equals.rs
@@ -42,7 +42,7 @@ where
     let mut start2 = rng2.start();
 
     while !rng1.is_end(&start1) && !rng2.is_end(&start2) {
-        if !bi_pred(rng1.at(&start1), rng2.at(&start2)) {
+        if !bi_pred(&rng1.at(&start1), &rng2.at(&start2)) {
             return false;
         }
         start1 = rng1.after(start1);
@@ -126,7 +126,7 @@ where
     let mut start1 = rng1.start();
     let mut start2 = rng2.start();
     while !rng1.is_end(&start1) && !rng2.is_end(&start2) {
-        if !bi_pred(rng1.at(&start1), rng2.at(&start2)) {
+        if !bi_pred(&rng1.at(&start1), &rng2.at(&start2)) {
             return false;
         }
         start1 = rng1.after(start1);

--- a/src/rng/find.rs
+++ b/src/rng/find.rs
@@ -37,7 +37,7 @@ where
 {
     let mut start = rng.start();
     while !rng.is_end(&start) {
-        if pred(rng.at(&start)) {
+        if pred(&rng.at(&start)) {
             break;
         }
         start = rng.after(start)

--- a/src/rng/for_each.rs
+++ b/src/rng/for_each.rs
@@ -35,7 +35,7 @@ where
 {
     let mut start = rng.start();
     while !rng.is_end(&start) {
-        op(rng.at(&start));
+        op(&rng.at(&start));
         start = rng.after(start);
     }
 }
@@ -70,7 +70,7 @@ where
 {
     let mut start = rng.start();
     while !rng.is_end(&start) {
-        op(rng.at_mut(&start));
+        op(&mut rng.at_mut(&start));
         start = rng.after(start);
     }
 }

--- a/src/rng/merge.rs
+++ b/src/rng/merge.rs
@@ -55,7 +55,7 @@ where
         if rng2.is_end(&start2) {
             return copy_till(rng1, start1, |i| rng1.is_end(i), dest, out);
         }
-        if is_less(rng2.at(&start2), rng1.at(&start1)) {
+        if is_less(&rng2.at(&start2), &rng1.at(&start1)) {
             *dest.at_mut(&out) = rng2.at(&start2).clone();
             start2 = rng2.after(start2);
         } else {

--- a/src/rng/minmax.rs
+++ b/src/rng/minmax.rs
@@ -51,7 +51,7 @@ where
     start = rng.after(start);
 
     while !rng.is_end(&start) {
-        if is_less(rng.at(&start), rng.at(&smallest)) {
+        if is_less(&rng.at(&start), &rng.at(&smallest)) {
             smallest = start.clone();
         }
         start = rng.after(start);
@@ -144,7 +144,7 @@ where
     start = rng.after(start);
 
     while !rng.is_end(&start) {
-        if !is_less(rng.at(&start), rng.at(&max)) {
+        if !is_less(&rng.at(&start), &rng.at(&max)) {
             max = start.clone();
         }
         start = rng.after(start);
@@ -248,7 +248,7 @@ where
         return (min, max);
     }
 
-    if is_less(rng.at(&start), rng.at(&min)) {
+    if is_less(&rng.at(&start), &rng.at(&min)) {
         min = start.clone();
     } else {
         max = start.clone();
@@ -260,24 +260,24 @@ where
         let i = start.clone();
         start = rng.after(start);
         if rng.is_end(&start) {
-            if is_less(rng.at(&i), rng.at(&min)) {
+            if is_less(&rng.at(&i), &rng.at(&min)) {
                 min = i;
-            } else if !is_less(rng.at(&i), rng.at(&max)) {
+            } else if !is_less(&rng.at(&i), &rng.at(&max)) {
                 max = i;
             }
             break;
-        } else if is_less(rng.at(&start), rng.at(&i)) {
-            if is_less(rng.at(&start), rng.at(&min)) {
+        } else if is_less(&rng.at(&start), &rng.at(&i)) {
+            if is_less(&rng.at(&start), &rng.at(&min)) {
                 min = start.clone();
             }
-            if !is_less(rng.at(&i), rng.at(&max)) {
+            if !is_less(&rng.at(&i), &rng.at(&max)) {
                 max = i;
             }
         } else {
-            if is_less(rng.at(&i), rng.at(&min)) {
+            if is_less(&rng.at(&i), &rng.at(&min)) {
                 min = i;
             }
-            if !is_less(rng.at(&start), rng.at(&max)) {
+            if !is_less(&rng.at(&start), &rng.at(&max)) {
                 max = start.clone();
             }
         }

--- a/src/rng/mismatch.rs
+++ b/src/rng/mismatch.rs
@@ -44,7 +44,7 @@ where
     let mut start2 = rng2.start();
 
     while !rng1.is_end(&start1) && !rng2.is_end(&start2) {
-        if !bi_pred(rng1.at(&start1), rng2.at(&start2)) {
+        if !bi_pred(&rng1.at(&start1), &rng2.at(&start2)) {
             return (start1, start2);
         }
         start1 = rng1.after(start1);

--- a/src/rng/numeric.rs
+++ b/src/rng/numeric.rs
@@ -48,7 +48,7 @@ where
 {
     let mut start = rng.start();
     while !rng.is_end(&start) {
-        init = op(init, rng.at(&start));
+        init = op(init, &rng.at(&start));
         start = rng.after(start);
     }
     init

--- a/src/rng/of.rs
+++ b/src/rng/of.rs
@@ -33,7 +33,7 @@ where
 {
     let mut start = rng.start();
     while !rng.is_end(&start) {
-        if !pred(rng.at(&start)) {
+        if !pred(&rng.at(&start)) {
             return false;
         }
         start = rng.after(start);
@@ -71,7 +71,7 @@ where
 {
     let mut start = rng.start();
     while !rng.is_end(&start) {
-        if pred(rng.at(&start)) {
+        if pred(&rng.at(&start)) {
             return true;
         }
         start = rng.after(start);
@@ -109,7 +109,7 @@ where
 {
     let mut start = rng.start();
     while !rng.is_end(&start) {
-        if pred(rng.at(&start)) {
+        if pred(&rng.at(&start)) {
             return false;
         }
         start = rng.after(start);

--- a/src/rng/partition.rs
+++ b/src/rng/partition.rs
@@ -92,7 +92,7 @@ where
 {
     let mut start = rng.start();
     while !rng.is_end(&start) {
-        if !pred(rng.at(&start)) {
+        if !pred(&rng.at(&start)) {
             break;
         }
         start = rng.after(start);
@@ -104,7 +104,7 @@ where
 
     let mut i = rng.after(start.clone());
     while !rng.is_end(&i) {
-        if pred(rng.at(&i)) {
+        if pred(&rng.at(&i)) {
             rng.swap_at(&i, &start);
             start = rng.after(start);
         }

--- a/src/rng/partition.rs
+++ b/src/rng/partition.rs
@@ -33,14 +33,14 @@ where
 {
     let mut start = rng.start();
     while !rng.is_end(&start) {
-        if !pred(rng.at(&start)) {
+        if !pred(&rng.at(&start)) {
             break;
         }
         start = rng.after(start);
     }
 
     while !rng.is_end(&start) {
-        if pred(rng.at(&start)) {
+        if pred(&rng.at(&start)) {
             return false;
         }
         start = rng.after(start);

--- a/src/rng/remove.rs
+++ b/src/rng/remove.rs
@@ -42,7 +42,7 @@ where
 {
     let mut start = rng.start();
     while !rng.is_end(&start) {
-        if pred(rng.at(&start)) {
+        if pred(&rng.at(&start)) {
             break;
         }
         start = rng.after(start);
@@ -50,7 +50,7 @@ where
     if !rng.is_end(&start) {
         let mut i = rng.after(start.clone());
         while !rng.is_end(&i) {
-            if !pred(rng.at(&i)) {
+            if !pred(&rng.at(&i)) {
                 rng.swap_at(&i, &start);
                 start = rng.after(start);
             }
@@ -143,7 +143,7 @@ where
     let mut start = src.start();
     let mut out = dest.start();
     while !src.is_end(&start) {
-        if !pred(src.at(&start)) {
+        if !pred(&src.at(&start)) {
             *dest.at_mut(&out) = src.at(&start).clone();
             out = dest.after(out);
         }

--- a/src/rng/replace.rs
+++ b/src/rng/replace.rs
@@ -40,7 +40,7 @@ pub fn replace_if<Range, Pred>(
 {
     let mut start = rng.start();
     while !rng.is_end(&start) {
-        if pred(rng.at(&start)) {
+        if pred(&rng.at(&start)) {
             *rng.at_mut(&start) = new_e.clone();
         }
         start = rng.after(start);
@@ -125,7 +125,7 @@ where
     let mut start = src.start();
     let mut out = dest.start();
     while !src.is_end(&start) {
-        if pred(src.at(&start)) {
+        if pred(&src.at(&start)) {
             *dest.at_mut(&out) = new_e.clone();
         } else {
             *dest.at_mut(&out) = src.at(&start).clone();

--- a/src/rng/sort.rs
+++ b/src/rng/sort.rs
@@ -325,7 +325,7 @@ where
     let mut prev = start.clone();
     start = rng.after(start);
     while !rng.is_end(&start) {
-        if is_less(rng.at(&start), rng.at(&prev)) {
+        if is_less(&rng.at(&start), &rng.at(&prev)) {
             return start;
         }
         prev = start.clone();

--- a/src/rng/swap_ranges.rs
+++ b/src/rng/swap_ranges.rs
@@ -42,7 +42,10 @@ where
     let mut start2 = rng2.start();
 
     while !rng1.is_end(&start1) && !rng2.is_end(&start2) {
-        std::mem::swap(rng1.at_mut(&start1), rng2.at_mut(&start2));
+        std::mem::swap(
+            (&mut rng1.at_mut(&start1)) as &mut R1::Element,
+            (&mut rng2.at_mut(&start2)) as &mut R2::Element,
+        );
         start1 = rng1.after(start1);
         start2 = rng2.after(start2);
     }

--- a/src/rng/transform.rs
+++ b/src/rng/transform.rs
@@ -43,7 +43,7 @@ where
     let mut start = src.start();
     let mut out = dest.start();
     while !src.is_end(&start) {
-        *dest.at_mut(&out) = unary_op(src.at(&start));
+        *dest.at_mut(&out) = unary_op(&src.at(&start));
         start = src.after(start);
         out = dest.after(out);
     }
@@ -93,7 +93,7 @@ where
     let mut start2 = rng2.start();
     let mut out = dest.start();
     while !rng1.is_end(&start1) && !rng2.is_end(&start2) {
-        *dest.at_mut(&out) = binary_op(rng1.at(&start1), rng2.at(&start2));
+        *dest.at_mut(&out) = binary_op(&rng1.at(&start1), &rng2.at(&start2));
         start1 = rng1.after(start1);
         start2 = rng2.after(start2);
         out = dest.after(out);

--- a/src/rng/unique.rs
+++ b/src/rng/unique.rs
@@ -54,7 +54,7 @@ where
     let mut result = start.clone();
     start = rng.after(start);
     while !rng.is_end(&start) {
-        if !bi_pred(rng.at(&result), rng.at(&start)) {
+        if !bi_pred(&rng.at(&result), &rng.at(&start)) {
             result = rng.after(result);
             if result != start {
                 rng.swap_at(&result, &start);
@@ -189,7 +189,7 @@ where
     *dest.at_mut(&out) = src.at(&start).clone();
     start = src.after(start);
     while !src.is_end(&start) {
-        if !bi_pred(dest.at(&out), src.at(&start)) {
+        if !bi_pred(&dest.at(&out), &src.at(&start)) {
             out = dest.after(out);
             *dest.at_mut(&out) = src.at(&start).clone();
         }

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -70,7 +70,12 @@ impl<T> SemiOutputRange for [T] {
 }
 
 impl<T> OutputRange for [T] {
-    fn at_mut(&mut self, i: &Self::Position) -> &mut Self::Element {
+    type ElementMutRef<'a>
+        = &'a mut T
+    where
+        Self: 'a;
+
+    fn at_mut<'a>(&'a mut self, i: &Self::Position) -> Self::ElementMutRef<'a> {
         &mut self[*i]
     }
 }

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -11,6 +11,11 @@ use crate::{
 impl<T> InputRange for [T] {
     type Element = T;
 
+    type ElementRef<'a>
+        = &'a T
+    where
+        Self: 'a;
+
     type Position = usize;
 
     fn start(&self) -> Self::Position {
@@ -25,7 +30,7 @@ impl<T> InputRange for [T] {
         i + n
     }
 
-    fn at(&self, i: &Self::Position) -> &Self::Element {
+    fn at<'a>(&'a self, i: &Self::Position) -> Self::ElementRef<'a> {
         &self[*i]
     }
 

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -70,7 +70,12 @@ impl<T> SemiOutputRange for Vec<T> {
 }
 
 impl<T> OutputRange for Vec<T> {
-    fn at_mut(&mut self, i: &Self::Position) -> &mut Self::Element {
+    type ElementMutRef<'a>
+        = &'a mut T
+    where
+        Self: 'a;
+
+    fn at_mut<'a>(&'a mut self, i: &Self::Position) -> Self::ElementMutRef<'a> {
         &mut self[*i]
     }
 }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -11,6 +11,11 @@ use crate::{
 impl<T> InputRange for Vec<T> {
     type Element = T;
 
+    type ElementRef<'a>
+        = &'a T
+    where
+        Self: 'a;
+
     type Position = usize;
 
     fn start(&self) -> Self::Position {
@@ -25,7 +30,7 @@ impl<T> InputRange for Vec<T> {
         i + n
     }
 
-    fn at(&self, i: &Self::Position) -> &Self::Element {
+    fn at<'a>(&'a self, i: &Self::Position) -> Self::ElementRef<'a> {
         &self[*i]
     }
 

--- a/src/view.rs
+++ b/src/view.rs
@@ -54,6 +54,12 @@ pub mod __view_details {
     {
         type Element = R::Element;
 
+        type ElementRef<'a>
+            = R::ElementRef<'a>
+        where
+            R: 'a,
+            Self: 'a;
+
         type Position = R::Position;
 
         fn start(&self) -> Self::Position {
@@ -68,7 +74,7 @@ pub mod __view_details {
             self.range.after(i)
         }
 
-        fn at(&self, i: &Self::Position) -> &Self::Element {
+        fn at<'a>(&'a self, i: &Self::Position) -> Self::ElementRef<'a> {
             self.range.at(i)
         }
 
@@ -83,6 +89,12 @@ pub mod __view_details {
     {
         type Element = R::Element;
 
+        type ElementRef<'a>
+            = R::ElementRef<'a>
+        where
+            R: 'a,
+            Self: 'a;
+
         type Position = R::Position;
 
         fn start(&self) -> Self::Position {
@@ -97,7 +109,7 @@ pub mod __view_details {
             self.range.after(i)
         }
 
-        fn at(&self, i: &Self::Position) -> &Self::Element {
+        fn at<'a>(&'a self, i: &Self::Position) -> Self::ElementRef<'a> {
             self.range.at(i)
         }
 
@@ -190,7 +202,16 @@ pub mod __view_details {
     where
         R: OutputRange + ?Sized,
     {
-        fn at_mut(&mut self, i: &Self::Position) -> &mut Self::Element {
+        type ElementMutRef<'a>
+            = R::ElementMutRef<'a>
+        where
+            R: 'a,
+            Self: 'a;
+
+        fn at_mut<'a>(
+            &'a mut self,
+            i: &Self::Position,
+        ) -> Self::ElementMutRef<'a> {
             self.range.at_mut(i)
         }
     }

--- a/src/view.rs
+++ b/src/view.rs
@@ -260,3 +260,8 @@ pub trait STLMutableViewExt: SemiOutputRange {
 }
 
 impl<R> STLMutableViewExt for R where R: SemiOutputRange + ?Sized {}
+
+#[doc(hidden)]
+pub mod ints;
+#[doc(inline)]
+pub use ints::*;

--- a/src/view/ints.rs
+++ b/src/view/ints.rs
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024 Rishabh Dwivedi (rishabhdwivedi17@gmail.com)
+
+#[doc(hidden)]
+pub mod __details_view_ints {
+    use crate::{
+        BidirectionalRange, ForwardRange, InputRange, RandomAccessRange, View,
+    };
+
+    pub struct IntView {
+        pub init: i32,
+    }
+
+    pub struct IntViewRef {
+        pub val: i32,
+    }
+
+    impl std::ops::Deref for IntViewRef {
+        type Target = i32;
+
+        fn deref(&self) -> &Self::Target {
+            &self.val
+        }
+    }
+
+    impl InputRange for IntView {
+        type Element = i32;
+
+        type ElementRef<'a>
+            = IntViewRef
+        where
+            Self: 'a;
+
+        type Position = i32;
+
+        fn start(&self) -> Self::Position {
+            self.init
+        }
+
+        fn is_end(&self, _: &Self::Position) -> bool {
+            false
+        }
+
+        fn after(&self, i: Self::Position) -> Self::Position {
+            i + 1
+        }
+
+        fn at<'a>(&'a self, i: &Self::Position) -> Self::ElementRef<'a> {
+            IntViewRef { val: *i }
+        }
+
+        fn after_n(&self, i: Self::Position, n: usize) -> Self::Position {
+            i + n as i32
+        }
+    }
+
+    impl View for IntView {}
+
+    impl ForwardRange for IntView {
+        fn distance(&self, from: Self::Position, to: Self::Position) -> usize {
+            (to - from) as usize
+        }
+    }
+
+    impl BidirectionalRange for IntView {
+        fn before(&self, i: Self::Position) -> Self::Position {
+            i - 1
+        }
+
+        fn before_n(&self, i: Self::Position, n: usize) -> Self::Position {
+            i - n as i32
+        }
+    }
+
+    impl RandomAccessRange for IntView {}
+}
+
+/// Returns an infinite sequence of i32s starting from init.
+///
+/// # Precondition
+///
+/// # Postcondition
+///   - InputRange -> YES
+///   - ForwardRange -> YES
+///   - BidirectionalRange -> YES
+///   - RandomAccessRange -> YES
+///
+/// # Example
+/// ```rust
+/// use stl::*;
+/// use rng::infix::*;
+///
+/// let nums = view::ints(0);
+/// let i = nums.find_if(|x| *x == 10);
+/// assert_eq!(i, 10);
+/// ```
+pub fn ints(init: i32) -> __details_view_ints::IntView {
+    __details_view_ints::IntView { init }
+}

--- a/tests/ints_view_test.rs
+++ b/tests/ints_view_test.rs
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024 Rishabh Dwivedi (rishabhdwivedi17@gmail.com)
+
+#[cfg(test)]
+pub mod tests {
+    use rng::infix::*;
+    use stl::*;
+
+    #[test]
+    fn ints() {
+        let nums = view::ints(0);
+
+        let mut i = nums.find(&10);
+        assert_eq!(i, 10);
+
+        i = nums.after_n(i, 3);
+        assert_eq!(i, 13);
+        assert_eq!(*nums.at(&i), 13);
+
+        i = nums.before(i);
+        assert_eq!(i, 12);
+        assert_eq!(*nums.at(&i), 12);
+    }
+}

--- a/tests/rotate_test.rs
+++ b/tests/rotate_test.rs
@@ -10,6 +10,11 @@ struct ForwardArray<const N: usize> {
 impl<const N: usize> InputRange for ForwardArray<N> {
     type Element = i32;
 
+    type ElementRef<'a>
+        = &'a i32
+    where
+        Self: 'a;
+
     type Position = usize;
 
     fn start(&self) -> Self::Position {
@@ -20,7 +25,7 @@ impl<const N: usize> InputRange for ForwardArray<N> {
         i + 1
     }
 
-    fn at(&self, i: &Self::Position) -> &Self::Element {
+    fn at<'a>(&'a self, i: &Self::Position) -> Self::ElementRef<'a> {
         &self.arr[*i]
     }
 


### PR DESCRIPTION
Currently `.at()` and `.at_mut()` methods of ranges used to return `&Range::Element` and `&mut Range::Element`. This is most intuitive thing to do, however with introduction of views, it is not necessary that there exists an element of type &Range::Element with that view like `view::sequence(0, |x| *x + 1)`.

For handling the same, now at and at_mut function returns ElementRef and ElementMutRef type, that is bounded to be dereferencable to Element. These objects can be treated as proxy references for the usecase.

To demonstrate the same, `views::ints` view has been put as part of PR.