### PR TITLE
Add Collection trait to represent range whose elements are there in memory

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -4,8 +4,8 @@
 #![doc(hidden)]
 
 use crate::{
-    BidirectionalRange, BoundedRange, ForwardRange, InputRange, OutputRange,
-    RandomAccessRange, SemiOutputRange,
+    BidirectionalRange, BoundedRange, Collection, ForwardRange, InputRange,
+    OutputRange, RandomAccessRange, SemiOutputRange,
 };
 
 impl<T, const N: usize> InputRange for [T; N] {
@@ -38,6 +38,8 @@ impl<T, const N: usize> InputRange for [T; N] {
         *i == N
     }
 }
+
+impl<'a, T, const N: usize> Collection<'a> for [T; N] where Self: 'a {}
 
 impl<T, const N: usize> BoundedRange for [T; N] {
     fn end(&self) -> Self::Position {

--- a/src/core.rs
+++ b/src/core.rs
@@ -86,6 +86,13 @@ pub trait InputRange {
     fn at<'a>(&'a self, i: &Self::Position) -> Self::ElementRef<'a>;
 }
 
+pub trait Collection<'a>:
+    InputRange<ElementRef<'a> = &'a <Self as InputRange>::Element>
+where
+    Self: 'a,
+{
+}
+
 /// Models a bounded range, i.e., the range whose end position is known.
 pub trait BoundedRange: InputRange {
     /// Returns position immediately after position of last element.

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -4,8 +4,8 @@
 #![doc(hidden)]
 
 use crate::{
-    BidirectionalRange, BoundedRange, ForwardRange, InputRange, OutputRange,
-    RandomAccessRange, SemiOutputRange,
+    BidirectionalRange, BoundedRange, Collection, ForwardRange, InputRange,
+    OutputRange, RandomAccessRange, SemiOutputRange,
 };
 
 impl<T> InputRange for [T] {
@@ -38,6 +38,8 @@ impl<T> InputRange for [T] {
         *i == self.len()
     }
 }
+
+impl<'a, T> Collection<'a> for [T] where Self: 'a {}
 
 impl<T> BoundedRange for [T] {
     fn end(&self) -> Self::Position {

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -4,8 +4,8 @@
 #![doc(hidden)]
 
 use crate::{
-    BidirectionalRange, BoundedRange, ForwardRange, InputRange, OutputRange,
-    RandomAccessRange, SemiOutputRange,
+    BidirectionalRange, BoundedRange, Collection, ForwardRange, InputRange,
+    OutputRange, RandomAccessRange, SemiOutputRange,
 };
 
 impl<T> InputRange for Vec<T> {
@@ -38,6 +38,8 @@ impl<T> InputRange for Vec<T> {
         *i == self.len()
     }
 }
+
+impl<'a, T> Collection<'a> for Vec<T> where Self: 'a {}
 
 impl<T> BoundedRange for Vec<T> {
     fn end(&self) -> Self::Position {

--- a/src/view.rs
+++ b/src/view.rs
@@ -31,7 +31,7 @@ use crate::{InputRange, SemiOutputRange};
 
 mod __details {
     use crate::{
-        BidirectionalRange, BoundedRange, ForwardRange, InputRange,
+        BidirectionalRange, BoundedRange, Collection, ForwardRange, InputRange,
         OutputRange, RandomAccessRange, SemiOutputRange, View,
     };
 
@@ -123,6 +123,20 @@ mod __details {
         fn after_n(&self, i: Self::Position, n: usize) -> Self::Position {
             self.range.after_n(i, n)
         }
+    }
+
+    impl<'a, R> Collection<'a> for RangeView<'_, R>
+    where
+        R: Collection<'a> + ?Sized,
+        Self: 'a,
+    {
+    }
+
+    impl<'a, R> Collection<'a> for RangeMutView<'_, R>
+    where
+        R: Collection<'a> + SemiOutputRange + ?Sized,
+        Self: 'a,
+    {
     }
 
     impl<R> BoundedRange for RangeView<'_, R>

--- a/src/view/join.rs
+++ b/src/view/join.rs
@@ -1,20 +1,19 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2024 Rishabh Dwivedi (rishabhdwivedi17@gmail.com)
 
-use crate::{InputRange, View};
+use crate::{Collection, InputRange, View};
 
 mod __details {
     use crate::{
-        BidirectionalRange, BoundedRange, ForwardRange, InputRange, View,
+        BidirectionalRange, BoundedRange, Collection, ForwardRange, InputRange,
+        View,
     };
 
     #[derive(Clone)]
     pub struct JoinView<Element, InRange, OutRange>
     where
         InRange: InputRange<Element = Element>,
-        for<'a> OutRange: 'a
-            + InputRange<Element = InRange, ElementRef<'a> = &'a InRange>
-            + View,
+        for<'a> OutRange: Collection<'a, Element = InRange> + View,
     {
         pub range: OutRange,
     }
@@ -31,9 +30,8 @@ mod __details {
     ) -> JoinPosition<OutRange::Position, InRange::Position>
     where
         InRange: BidirectionalRange<Element = Element> + BoundedRange,
-        for<'a> OutRange: 'a
-            + BidirectionalRange<Element = InRange, ElementRef<'a> = &'a InRange>
-            + View,
+        for<'a> OutRange:
+            Collection<'a, Element = InRange> + BidirectionalRange + View,
     {
         while out_pos != rng.range.start() {
             out_pos = rng.range.before(out_pos);
@@ -51,9 +49,7 @@ mod __details {
         for JoinView<Element, InRange, OutRange>
     where
         InRange: InputRange<Element = Element>,
-        for<'a> OutRange: 'a
-            + InputRange<Element = InRange, ElementRef<'a> = &'a InRange>
-            + View,
+        for<'a> OutRange: Collection<'a, Element = InRange> + View,
     {
         type Element = Element;
 
@@ -122,9 +118,7 @@ mod __details {
     impl<Element, InRange, OutRange> View for JoinView<Element, InRange, OutRange>
     where
         InRange: InputRange<Element = Element>,
-        for<'a> OutRange: 'a
-            + InputRange<Element = InRange, ElementRef<'a> = &'a InRange>
-            + View,
+        for<'a> OutRange: Collection<'a, Element = InRange> + View,
     {
     }
 
@@ -132,9 +126,8 @@ mod __details {
         for JoinView<Element, InRange, OutRange>
     where
         InRange: InputRange<Element = Element>,
-        for<'a> OutRange: 'a
-            + BoundedRange<Element = InRange, ElementRef<'a> = &'a InRange>
-            + View,
+        for<'a> OutRange:
+            Collection<'a, Element = InRange> + BoundedRange + View,
     {
         fn end(&self) -> Self::Position {
             JoinPosition::End(self.range.end())
@@ -145,9 +138,8 @@ mod __details {
         for JoinView<Element, InRange, OutRange>
     where
         InRange: ForwardRange<Element = Element>,
-        for<'a> OutRange: 'a
-            + ForwardRange<Element = InRange, ElementRef<'a> = &'a InRange>
-            + View,
+        for<'a> OutRange:
+            Collection<'a, Element = InRange> + ForwardRange + View,
     {
     }
 
@@ -155,9 +147,8 @@ mod __details {
         for JoinView<Element, InRange, OutRange>
     where
         InRange: BidirectionalRange<Element = Element> + BoundedRange,
-        for<'a> OutRange: 'a
-            + BidirectionalRange<Element = InRange, ElementRef<'a> = &'a InRange>
-            + View,
+        for<'a> OutRange:
+            Collection<'a, Element = InRange> + BidirectionalRange + View,
     {
         fn before(&self, i: Self::Position) -> Self::Position {
             match i {
@@ -220,26 +211,22 @@ pub fn join<Element, InRange, OutRange>(
 ) -> __details::JoinView<Element, InRange, OutRange>
 where
     InRange: InputRange<Element = Element>,
-    for<'a> OutRange:
-        'a + InputRange<Element = InRange, ElementRef<'a> = &'a InRange> + View,
+    for<'a> OutRange: Collection<'a, Element = InRange> + View,
 {
     __details::JoinView { range: view }
 }
 
 pub mod infix {
     use super::__details;
-    use crate::{InputRange, View};
+    use crate::{Collection, InputRange, View};
 
-    pub trait STLJoinExt<Element, InRange>:
-        InputRange<Element = InRange> + View + Sized
+    pub trait STLJoinExt<Element, InRange>: View + Sized
     where
         InRange: InputRange<Element = Element>,
     {
         fn join(self) -> __details::JoinView<Element, InRange, Self>
         where
-            for<'a> Self: 'a
-                + InputRange<Element = InRange, ElementRef<'a> = &'a InRange>
-                + View,
+            for<'b> Self: Collection<'b, Element = InRange> + View,
         {
             super::join(self)
         }
@@ -249,9 +236,7 @@ pub mod infix {
     where
         T: InputRange<Element = InRange> + View,
         InRange: InputRange<Element = Element>,
-        for<'a> T: 'a
-            + InputRange<Element = InRange, ElementRef<'a> = &'a InRange>
-            + View,
+        for<'a> T: Collection<'a, Element = InRange> + View,
     {
     }
 }


### PR DESCRIPTION
A range represents a linear sequence of elements. However, its not necessary if those elements are laid down in the memory. Sometimes, this is necessary condition to work with (`view::join`). I am not sure if that is worthy enough to have a specific name, but I am calling that  a `Collection` in this PR. If it would be worthy, then this PR can be perceived forward.

`Collection` also suffers from the the borrow checker limitation (See #12).