### PR TITLE
Explore single pass peekable sequences

### DIFF
--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -8,7 +8,9 @@ pub trait PeekableIterator: Iterator {
 }
 
 /// Models a factory of PeekableIterator
-pub trait IntoPeekableIterator: IntoIterator {
+pub trait IntoPeekableIterator:
+    IntoIterator<IntoIter: PeekableIterator>
+{
     /// Returns peekable iterator by consuming self.
     fn into_peekable_iter(self) -> Self::IntoIter;
 }

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 Rishabh Dwivedi (rishabhdwivedi17@gmail.com)
+
+/// Models a single pass sequence, whose current element can be peeked.
+pub trait PeekableIterator: Iterator {
+    /// Returns reference to current item of iterator.
+    fn peek(&self) -> Option<&Self::Item>;
+}
+
+/// Models a factory of PeekableIterator
+pub trait IntoPeekableIterator: IntoIterator {
+    /// Returns peekable iterator by consuming self.
+    fn into_peekable_iter(self) -> Self::IntoIter;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,10 @@ mod slice_mut;
 #[doc(inline)]
 pub use slice_mut::*;
 
+mod iterator;
+#[doc(inline)]
+pub use iterator::*;
+
 mod algo;
 #[doc(inline)]
 pub use algo::*;


### PR DESCRIPTION
Peekable sequences are mentioned in [https://github.com/orgs/hylo-lang/discussions/1668](https://github.com/orgs/hylo-lang/discussions/1668) lies between the abstraction of `Iterator` and `Collection`.

So, an `Iterator` is a single pass sequence and `Collection` brings multi pass sequences. There is a mid abstraction where current element can be queried multiple times. I see that, this can be used for writing things like parsers.

### Design
`Iterator` trait exists in rust, so this PR adds `PeekableIterator` trait. For any data structure that can produce `PeekableIterator` should implement `IntoPeekableIterator`. (Names can be reconsidered).
`PeekableIterator: Iterator` and `IntoPeekableIterator: IntoIterator`.

Data structures like linked list are good candidates for `IntoPeekableIterator` as they support `pop_first` operation.

### Goals
I am not very sure of goals yet. I see I can write this kind of code, that is not possible with `Iterator` and `Collection`:
```rust
fn parse_conditionally<Stream, Pred>(
    stream: &mut Stream,
    pred: Pred,
) -> Option<Stream::Item>
where
    Stream: PeekableIterator,
    Pred: Fn(&Stream::Item) -> bool,
{
    if let Some(token) = stream.peek() {
        if pred(token) {
            return stream.next();
        }
    }
    None
}
```
So, this abstraction must be an important abstraction for domain specific algorithms (based on what `Stream` actually is) e.g., parsing.