### PR TITLE
Explore Lazy Collections

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -262,3 +262,76 @@ Similar properties are held for `SliceMut` type.
 For convenience, `all`, `prefix`, `suffix`, `all_mut`, `prefix_mut`,
 `suffix_mut` methods are also provided as algorithms in addition to `slice` and
 `slice_mut` method for slicing.
+
+## Iterators
+
+Collections expose iterators using `.iter()` method. This actually helps to
+use all existing single pass algorithms on Iterators. Iterators returned by
+collections iterate over `ElementRef`.
+
+LazyCollection also exposes `.lazy_iter()` method, that traverses over
+`Element`.
+
+## Language Limitations
+
+There are some language limitations rs-stl suffer with. This leads to some
+ugly corners in library that is unavoidable.
+
+### Lifetime GATs are useless right now
+
+Ideally `Collection` should expose `iter()` method and `MutableCollection`
+should expose `iter_mut()` method. However, current implementation of `iter()`
+is very tricky and `iter_mut()` is not even possible.
+
+For solving the same `LendingIterator` is required whose `Item` associated type
+is lifetime bounded. However, `for<..>` syntax works really bad with `LendingIterator`.
+
+So, we need to settle on the hacky version of `iter()`.
+
+Also, this leads to introduction of `Whole` associated type in `Collection` trait.
+Ideally, it should have `Slice<'a>` associated type that would enable to have
+custom slice for every collection.
+
+### Lack of yield-once coroutines
+
+Swift's subscript operator provide ability to `yield` element. This is actually
+really helpful to project `ephermal` parts of data structure. This enables
+swift to have `Collection` trait that doesn't require `Element` in memory.
+
+However, rs-stl needs to incorporate proxy references using `ElementRef` for the
+same purpose. This is actually ugly and hurts ergonomics of API. Even worse is
+rust community doesn't seem to be very enthusiastic about this feature.
+
+With yield-once coroutine, `at` method can return reference to elements that
+doesn't actually exist in memory and API would be really simple:
+
+```rust
+    fn at(&self, i: &Self::Position) -> &Self::Element;
+```
+
+### Unable of handling recursive trait conditionals
+
+For example this just not compiles:
+
+```rust
+pub trait LazyCollection: Collection<Whole: LazyCollection> {
+    // details here...
+}
+```
+
+So one needs to write `Whole: LazyCollection` all the time one might want to
+depends on `LazyCollection` extension.
+
+### Lack of extension keyword
+
+Swift has really great extension keyword which enables to add methods to
+traits/structs after the definition of trait/structs.
+
+This enables Single Responsibility Principle as trait would only include
+the core/primitive methods required for implementing the trait. Other algorithms
+can be provided as an extension to trait/struct.
+
+Currently for coping the same, `extension-traits` are used that requires
+defining another trait like `CollectionExt: Collection` and implement it for
+all `Collection`. This hurts ergonomics in terms of IDE perspective as end-user
+doesn't need to know about `CollectionExt`.

--- a/docs/design.md
+++ b/docs/design.md
@@ -25,10 +25,14 @@ on special types like `[T]`.
 
 ### Collection
 
+Collection is the base trait that formally defines the linear sequence of
+elements. Elements are not necessarily needed to be stored in memory.
+
 ```rust
 pub trait Collection {
     type Position: Regular;
     type Element;
+    type ElementRef<'a>: std::ops::Deref<Target = Self::Element>
     type Whole: Collection<
         Position = Self::Position,
         Element = Self::Element,
@@ -42,7 +46,8 @@ pub trait Collection {
     /// Returns position immediately after i
     fn next(&self, i: Self::Position) -> Self::Position;
     /// Access element at position i.
-    fn at(&self, i: &Self::Position) -> &Self::Element;
+    fn at(&self, i: &Self::Position) -> Self::ElementRef<'_>;
+    /// Returns a contiguous subrange of given collection.
     fn slice(
         &self,
         from: Self::Position,
@@ -150,6 +155,26 @@ where
 
 MutableCollection provides mutable access to any element in collection for
 supporting external mutation.
+
+## Collection Hierarchy in terms of laziness
+
+### LazyCollection
+
+LazyCollection is a collection whose elements are computed on element access.
+This suggests that the returned element are not actually stored in memory.
+
+LazyCollection trait is mostly for optimization purposes where one might
+need ownership of returned element, then it would avoid redundant copy.
+
+```rust
+pub trait LazyCollection: Collection
+where
+    Self::Whole: LazyCollection,
+{
+    /// Computes element at position `i`.
+    fn compute_at(&self, i: &Self::Position) -> Self::Element;
+}
+```
 
 ## Algorithms
 

--- a/src/algo/collection_ext/mod.rs
+++ b/src/algo/collection_ext/mod.rs
@@ -1,9 +1,14 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2025 Rishabh Dwivedi (rishabhdwivedi17@gmail.com)
 
-use crate::{Collection, Predicate, Slice};
+use crate::{Collection, CollectionIterator, Predicate, Slice};
 
 pub trait CollectionExt: Collection {
+    /// Returns a non-consuming iterator that iterates over `&Self::Element`.
+    fn iter(&self) -> CollectionIterator<Self::Whole> {
+        CollectionIterator::new(self.slice(self.start(), self.end()))
+    }
+
     /// Returns the first element, or nil if `self` is empty.
     fn first(&self) -> Option<<Self as Collection>::ElementRef<'_>> {
         if self.start() == self.end() {

--- a/src/algo/collection_ext/mod.rs
+++ b/src/algo/collection_ext/mod.rs
@@ -5,7 +5,7 @@ use crate::{Collection, Slice};
 
 pub trait CollectionExt: Collection {
     /// Returns the first element, or nil if `self` is empty.
-    fn first(&self) -> Option<&<Self as Collection>::Element> {
+    fn first(&self) -> Option<<Self as Collection>::ElementRef<'_>> {
         if self.start() == self.end() {
             None
         } else {
@@ -108,7 +108,7 @@ pub trait CollectionExt: Collection {
         let mut other1 = other.all();
         loop {
             match (self1.pop_first(), other1.pop_first()) {
-                (Some(x), Some(y)) if bi_pred(x, y) => {}
+                (Some(x), Some(y)) if bi_pred(&x, &y) => {}
                 (None, None) => return true,
                 _ => return false,
             }
@@ -167,8 +167,12 @@ pub trait CollectionExt: Collection {
         Pred: Fn(&Self::Element) -> bool,
     {
         let mut rest = self.all();
-        while let Some(x) = rest.first() {
-            if pred(x) {
+        loop {
+            if let Some(x) = rest.first() {
+                if pred(&x) {
+                    break;
+                }
+            } else {
                 break;
             }
             rest.drop_first();
@@ -200,7 +204,7 @@ pub trait CollectionExt: Collection {
         let mut start = self.start();
         let end = self.end();
         while start != end {
-            f(self.at(&start));
+            f(&self.at(&start));
             start = self.next(start);
         }
     }

--- a/src/algo/lazy_collection_ext/mod.rs
+++ b/src/algo/lazy_collection_ext/mod.rs
@@ -1,12 +1,21 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2025 Rishabh Dwivedi (rishabhdwivedi17@gmail.com)
 
-use crate::LazyCollection;
+use crate::{Collection, LazyCollection, LazyCollectionIterator};
 
 pub trait LazyCollectionExt: LazyCollection
 where
     Self::Whole: LazyCollection,
 {
+    /// Returns the "lazily computed" first element, or nil if `self` is empty.
+    fn lazy_first(&self) -> Option<<Self as Collection>::Element> {
+        if self.start() == self.end() {
+            None
+        } else {
+            Some(self.compute_at(&self.start()))
+        }
+    }
+
     /// Applies f to each "lazily computed" element of collection.
     ///
     /// # Precondition
@@ -34,6 +43,12 @@ where
             f(self.compute_at(&start));
             start = self.next(start);
         }
+    }
+
+    /// Returns a non-consuming iterator that iterates over `Self::Element`.
+    /// The iterator lazily computes the value on each `next` call.
+    fn lazy_iter(&self) -> LazyCollectionIterator<Self::Whole> {
+        LazyCollectionIterator::new(self.slice(self.start(), self.end()))
     }
 }
 

--- a/src/algo/lazy_collection_ext/mod.rs
+++ b/src/algo/lazy_collection_ext/mod.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 Rishabh Dwivedi (rishabhdwivedi17@gmail.com)
+
+use crate::LazyCollection;
+
+pub trait LazyCollectionExt: LazyCollection
+where
+    Self::Whole: LazyCollection,
+{
+    /// Applies f to each "lazily computed" element of collection.
+    ///
+    /// # Precondition
+    ///
+    /// # Postcondition
+    ///   - Applies f to each element of collection.
+    ///   - Complexity: O(n). Exactly n applications of f.
+    ///
+    /// # Example
+    /// ```rust
+    /// use stl::*;
+    ///
+    /// let arr = 1..4;
+    /// let mut sum = 0;
+    /// arr.lazy_for_each(|x| sum = sum + x);
+    /// assert_eq!(sum, 6);
+    /// ```
+    fn lazy_for_each<F>(&self, mut f: F)
+    where
+        F: FnMut(Self::Element),
+    {
+        let mut start = self.start();
+        let end = self.end();
+        while start != end {
+            f(self.compute_at(&start));
+            start = self.next(start);
+        }
+    }
+}
+
+impl<R> LazyCollectionExt for R
+where
+    R: LazyCollection + ?Sized,
+    R::Whole: LazyCollection,
+{
+}

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -4,6 +4,9 @@
 mod collection_ext;
 pub use collection_ext::*;
 
+mod lazy_collection_ext;
+pub use lazy_collection_ext::*;
+
 mod random_access_collection_ext;
 pub use random_access_collection_ext::*;
 

--- a/src/collection_iterator.rs
+++ b/src/collection_iterator.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2025 Rishabh Dwivedi (rishabhdwivedi17@gmail.com)
 
-use crate::{Collection, Slice};
+use crate::{Collection, LazyCollection, Slice};
 
 pub struct CollectionIterator<'a, Whole>
 where
@@ -27,6 +27,38 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         self.slice.pop_first()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let cnt = self.slice.underestimated_count();
+        (cnt, None)
+    }
+}
+
+pub struct LazyCollectionIterator<'a, Whole>
+where
+    Whole: LazyCollection<Whole = Whole>,
+{
+    slice: Slice<'a, Whole>,
+}
+
+impl<'a, Whole> LazyCollectionIterator<'a, Whole>
+where
+    Whole: LazyCollection<Whole = Whole>,
+{
+    pub fn new(slice: Slice<'a, Whole>) -> Self {
+        LazyCollectionIterator { slice }
+    }
+}
+
+impl<'a, Whole> Iterator for LazyCollectionIterator<'a, Whole>
+where
+    Whole: LazyCollection<Whole = Whole>,
+{
+    type Item = <Slice<'a, Whole> as Collection>::Element;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.slice.lazy_pop_first()
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/src/collection_iterator.rs
+++ b/src/collection_iterator.rs
@@ -23,7 +23,7 @@ impl<'a, Whole> Iterator for CollectionIterator<'a, Whole>
 where
     Whole: Collection<Whole = Whole>,
 {
-    type Item = &'a Whole::Element;
+    type Item = <Slice<'a, Whole> as Collection>::ElementRef<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.slice.pop_first()

--- a/src/core.rs
+++ b/src/core.rs
@@ -50,13 +50,14 @@ pub trait Collection {
     type Position: Regular;
 
     /// Type of element in the collection.
-    type Element; // TODO: Finalize what to do with LazyCollection?
+    type Element;
 
     /// Type that is like `&Element`. For collections whose elements are in
     /// memory, its simply `&Element`.
     type ElementRef<'a>: std::ops::Deref<Target = Self::Element>
     where
-        Self: 'a;
+        Self: 'a; // Someday if rust supports yield once coroutines like swift,
+                  // then this proxy reference technique is not needed.
 
     /// Type representing whole collection.
     /// i.e., `Self == Slice<W> ? W : Self`
@@ -171,7 +172,7 @@ pub trait Collection {
     }
 }
 
-/// Models a collection whose elements are computed on memory access.
+/// Models a collection whose elements are computed on element access.
 pub trait LazyCollection: Collection
 where
     Self::Whole: LazyCollection,

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2025 Rishabh Dwivedi (rishabhdwivedi17@gmail.com)
 
-use crate::{CollectionIterator, Slice, SliceMut};
+use crate::{Slice, SliceMut};
 
 /// Any type that is movable, destructable and equality comparable.
 ///
@@ -165,11 +165,6 @@ pub trait Collection {
         from: Self::Position,
         to: Self::Position,
     ) -> Slice<Self::Whole>;
-
-    /// Returns a non-consuming iterator that iterates over `&Self::Element`.
-    fn iter(&self) -> CollectionIterator<Self::Whole> {
-        CollectionIterator::new(self.slice(self.start(), self.end()))
-    }
 }
 
 /// Models a collection whose elements are computed on element access.

--- a/src/core.rs
+++ b/src/core.rs
@@ -36,6 +36,10 @@ pub trait Collection {
     /// Type of element in the collection.
     type Element; // TODO: Finalize what to do with LazyCollection?
 
+    type ElementRef<'a>: std::ops::Deref<Target = Self::Element>
+    where
+        Self: 'a;
+
     /// Type representing whole collection.
     /// i.e., `Self == Slice<W> ? W : Self`
     type Whole: Collection<
@@ -131,7 +135,7 @@ pub trait Collection {
     ///
     /// # Complexity Requirement
     ///   O(1)
-    fn at(&self, i: &Self::Position) -> &Self::Element;
+    fn at(&self, i: &Self::Position) -> Self::ElementRef<'_>;
 
     /// Returns slice of collection in positions [from, to).
     ///

--- a/src/core.rs
+++ b/src/core.rs
@@ -36,6 +36,8 @@ pub trait Collection {
     /// Type of element in the collection.
     type Element; // TODO: Finalize what to do with LazyCollection?
 
+    /// Type that is like `&Element`. For collections whose elements are in
+    /// memory, its simply `&Element`.
     type ElementRef<'a>: std::ops::Deref<Target = Self::Element>
     where
         Self: 'a;

--- a/src/core.rs
+++ b/src/core.rs
@@ -156,7 +156,10 @@ pub trait Collection {
 }
 
 /// Models a collection whose elements are computed on memory access.
-pub trait LazyCollection: Collection {
+pub trait LazyCollection: Collection
+where
+    Self::Whole: LazyCollection,
+{
     /// Computes element at position `i`.
     ///
     /// # Precondition

--- a/src/core.rs
+++ b/src/core.rs
@@ -136,7 +136,7 @@ pub trait Collection {
     ///   - i is a valid position in self and i != end()
     ///
     /// # Complexity Requirement
-    ///   O(1)
+    ///   - O(1)
     fn at(&self, i: &Self::Position) -> Self::ElementRef<'_>;
 
     /// Returns slice of collection in positions [from, to).
@@ -153,6 +153,18 @@ pub trait Collection {
     fn iter(&self) -> CollectionIterator<Self::Whole> {
         CollectionIterator::new(self.slice(self.start(), self.end()))
     }
+}
+
+/// Models a collection whose elements are computed on memory access.
+pub trait LazyCollection: Collection {
+    /// Computes element at position `i`.
+    ///
+    /// # Precondition
+    ///   - i is a valid position in self and i != end()
+    ///
+    /// # Complexity Requirement
+    ///   - O(1)
+    fn compute_at(&self, i: &Self::Position) -> Self::Element;
 }
 
 /// Models a bidirectional collection, which can be traversed forward as well as backward.
@@ -261,6 +273,6 @@ where
     ///   - i is a valid position in self and i != end()
     ///
     /// # Complexity Requirement
-    ///   O(1)
+    ///   - O(1)
     fn at_mut(&mut self, i: &Self::Position) -> &mut Self::Element;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,3 +32,5 @@ pub use algo::*;
 
 #[doc(hidden)]
 pub(crate) mod std_impl;
+
+mod value_ref;

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -57,6 +57,23 @@ where
     }
 }
 
+impl<Whole> Slice<'_, Whole>
+where
+    Whole: LazyCollection<Whole = Whole>,
+{
+    /// Removes and returns the "lazily computed" first element if non-empty; returns
+    /// None otherwise.
+    pub fn lazy_pop_first(&mut self) -> Option<<Self as Collection>::Element> {
+        if self.from == self.to {
+            None
+        } else {
+            let e = Some(self.whole.compute_at(&self.from));
+            self.whole.form_next(&mut self.from);
+            e
+        }
+    }
+}
+
 impl<Whole> Collection for Slice<'_, Whole>
 where
     Whole: Collection<Whole = Whole>,

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -31,7 +31,9 @@ where
 
     /// Removes and returns the first element if non-empty; returns
     /// None otherwise.
-    pub fn pop_first(&mut self) -> Option<&'a <Self as Collection>::Element> {
+    pub fn pop_first(
+        &mut self,
+    ) -> Option<<Self as Collection>::ElementRef<'a>> {
         if self.from == self.to {
             None
         } else {
@@ -60,6 +62,11 @@ where
     type Position = Whole::Position;
 
     type Element = Whole::Element;
+
+    type ElementRef<'a>
+        = Whole::ElementRef<'a>
+    where
+        Self: 'a;
 
     type Whole = Whole;
 
@@ -91,7 +98,7 @@ where
         self.whole.distance(from, to)
     }
 
-    fn at(&self, i: &Self::Position) -> &Self::Element {
+    fn at(&self, i: &Self::Position) -> Self::ElementRef<'_> {
         self.whole.at(i)
     }
 

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2025 Rishabh Dwivedi (rishabhdwivedi17@gmail.com)
 
-use crate::{BidirectionalCollection, Collection, RandomAccessCollection};
+use crate::{
+    BidirectionalCollection, Collection, LazyCollection, RandomAccessCollection,
+};
 
 #[derive(Clone, PartialEq, Eq)]
 pub struct Slice<'a, Whole>
@@ -108,6 +110,15 @@ where
         to: Self::Position,
     ) -> Slice<Self::Whole> {
         Slice::new(self.whole, from, to)
+    }
+}
+
+impl<Whole> LazyCollection for Slice<'_, Whole>
+where
+    Whole: LazyCollection<Whole = Whole>,
+{
+    fn compute_at(&self, i: &Self::Position) -> Self::Element {
+        self.whole.compute_at(i)
     }
 }
 

--- a/src/slice_mut.rs
+++ b/src/slice_mut.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2025 Rishabh Dwivedi (rishabhdwivedi17@gmail.com)
 
 use crate::{
-    BidirectionalCollection, Collection, MutableCollection,
+    BidirectionalCollection, Collection, LazyCollection, MutableCollection,
     RandomAccessCollection, ReorderableCollection, Slice,
 };
 
@@ -111,6 +111,15 @@ where
         to: Self::Position,
     ) -> Slice<Self::Whole> {
         Slice::new(self.whole, from, to)
+    }
+}
+
+impl<Whole> LazyCollection for SliceMut<'_, Whole>
+where
+    Whole: LazyCollection<Whole = Whole> + ReorderableCollection,
+{
+    fn compute_at(&self, i: &Self::Position) -> Self::Element {
+        self.whole.compute_at(i)
     }
 }
 

--- a/src/slice_mut.rs
+++ b/src/slice_mut.rs
@@ -58,6 +58,23 @@ where
     }
 }
 
+impl<Whole> SliceMut<'_, Whole>
+where
+    Whole: LazyCollection<Whole = Whole> + ReorderableCollection,
+{
+    /// Removes and returns the "lazily computed" first element if non-empty; returns
+    /// None otherwise.
+    pub fn lazy_pop_first(&mut self) -> Option<<Self as Collection>::Element> {
+        if self.from == self.to {
+            None
+        } else {
+            let e = Some(self.whole.compute_at(&self.from));
+            self.whole.form_next(&mut self.from);
+            e
+        }
+    }
+}
+
 impl<Whole> Collection for SliceMut<'_, Whole>
 where
     Whole: ReorderableCollection<Whole = Whole>,

--- a/src/slice_mut.rs
+++ b/src/slice_mut.rs
@@ -34,7 +34,9 @@ where
 
     /// Removes and returns the first element if non-empty; returns
     /// None otherwise.
-    pub fn pop_first(&mut self) -> Option<&<Self as Collection>::Element> {
+    pub fn pop_first(
+        &mut self,
+    ) -> Option<<Self as Collection>::ElementRef<'_>> {
         if self.from == self.to {
             None
         } else {
@@ -63,6 +65,11 @@ where
     type Position = Whole::Position;
 
     type Element = Whole::Element;
+
+    type ElementRef<'a>
+        = Whole::ElementRef<'a>
+    where
+        Self: 'a;
 
     type Whole = Whole;
 
@@ -94,7 +101,7 @@ where
         self.whole.distance(from, to)
     }
 
-    fn at(&self, i: &Self::Position) -> &Self::Element {
+    fn at(&self, i: &Self::Position) -> Self::ElementRef<'_> {
         self.whole.at(i)
     }
 

--- a/src/std_impl/array_impl.rs
+++ b/src/std_impl/array_impl.rs
@@ -11,6 +11,11 @@ impl<T, const N: usize> Collection for [T; N] {
 
     type Element = T;
 
+    type ElementRef<'a>
+        = &'a T
+    where
+        Self: 'a;
+
     type Whole = Self;
 
     fn start(&self) -> Self::Position {

--- a/src/std_impl/mod.rs
+++ b/src/std_impl/mod.rs
@@ -2,5 +2,6 @@
 // Copyright (c) 2025 Rishabh Dwivedi (rishabhdwivedi17@gmail.com)
 
 pub mod array_impl;
+pub mod range;
 pub mod slice_impl;
 pub mod vec_impl;

--- a/src/std_impl/range.rs
+++ b/src/std_impl/range.rs
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 Rishabh Dwivedi (rishabhdwivedi17@gmail.com)
+
+use std::ops::Range;
+use std::ops::RangeInclusive;
+
+use crate::{
+    value_ref::ValueRef, BidirectionalCollection, Collection, LazyCollection,
+    RandomAccessCollection, Slice,
+};
+
+macro_rules! impl_collection_for_range_inclusive {
+($($t:ty),*) => {
+  $(impl Collection for RangeInclusive<$t> {
+      type Position = $t;
+
+      type Element = $t;
+
+      type ElementRef<'a>
+          = ValueRef<$t>
+      where
+          Self: 'a;
+
+      type Whole = Self;
+
+      fn start(&self) -> Self::Position {
+          *self.start()
+      }
+
+      fn end(&self) -> Self::Position {
+          *self.end() + 1
+      }
+
+      fn form_next(&self, position: &mut Self::Position) {
+          *position += 1
+      }
+
+      fn at(&self, i: &Self::Position) -> Self::ElementRef<'_> {
+          ValueRef::new(*i)
+      }
+
+      fn slice(
+          &self,
+          from: Self::Position,
+          to: Self::Position,
+      ) -> crate::Slice<Self::Whole> {
+          Slice::new(self, from, to)
+      }
+
+      fn form_next_n(&self, position: &mut Self::Position, n: usize) {
+          *position += n as $t
+      }
+
+      fn distance(&self, from: Self::Position, to: Self::Position) -> usize {
+          (to - from) as usize
+      }
+  }
+
+  impl LazyCollection for RangeInclusive<$t> {
+      fn compute_at(&self, i: &Self::Position) -> Self::Element {
+          *i
+      }
+  }
+
+  impl BidirectionalCollection for RangeInclusive<$t> {
+      fn form_prior(&self, position: &mut Self::Position) {
+          *position -= 1
+      }
+
+      fn form_prior_n(&self, position: &mut Self::Position, n: usize) {
+          *position -= n as $t
+      }
+  }
+
+  impl RandomAccessCollection for RangeInclusive<$t> {})*
+};
+}
+
+impl_collection_for_range_inclusive!(
+    i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize
+);
+
+macro_rules! impl_collection_for_range {
+($($t:ty),*) => {
+  $(impl Collection for Range<$t> {
+      type Position = $t;
+
+      type Element = $t;
+
+      type ElementRef<'a>
+          = ValueRef<$t>
+      where
+          Self: 'a;
+
+      type Whole = Self;
+
+      fn start(&self) -> Self::Position {
+          self.start
+      }
+
+      fn end(&self) -> Self::Position {
+          self.end
+      }
+
+      fn form_next(&self, position: &mut Self::Position) {
+          *position += 1
+      }
+
+      fn at(&self, i: &Self::Position) -> Self::ElementRef<'_> {
+          ValueRef::new(*i)
+      }
+
+      fn slice(
+          &self,
+          from: Self::Position,
+          to: Self::Position,
+      ) -> crate::Slice<Self::Whole> {
+          Slice::new(self, from, to)
+      }
+
+      fn form_next_n(&self, position: &mut Self::Position, n: usize) {
+          *position += n as $t
+      }
+
+      fn distance(&self, from: Self::Position, to: Self::Position) -> usize {
+          (to - from) as usize
+      }
+  }
+
+  impl LazyCollection for Range<$t> {
+      fn compute_at(&self, i: &Self::Position) -> Self::Element {
+          *i
+      }
+  }
+
+  impl BidirectionalCollection for Range<$t> {
+      fn form_prior(&self, position: &mut Self::Position) {
+          *position -= 1
+      }
+
+      fn form_prior_n(&self, position: &mut Self::Position, n: usize) {
+          *position -= n as $t
+      }
+  }
+
+  impl RandomAccessCollection for Range<$t> {})*
+};
+}
+
+impl_collection_for_range!(
+    i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize
+);

--- a/src/std_impl/slice_impl.rs
+++ b/src/std_impl/slice_impl.rs
@@ -11,6 +11,11 @@ impl<T> Collection for &[T] {
 
     type Element = T;
 
+    type ElementRef<'a>
+        = &'a T
+    where
+        Self: 'a;
+
     type Whole = Self;
 
     fn start(&self) -> Self::Position {
@@ -62,6 +67,11 @@ impl<T> Collection for &mut [T] {
     type Position = usize;
 
     type Element = T;
+
+    type ElementRef<'a>
+        = &'a T
+    where
+        Self: 'a;
 
     type Whole = Self;
 

--- a/src/std_impl/vec_impl.rs
+++ b/src/std_impl/vec_impl.rs
@@ -11,6 +11,11 @@ impl<T> Collection for Vec<T> {
 
     type Element = T;
 
+    type ElementRef<'a>
+        = &'a T
+    where
+        Self: 'a;
+
     type Whole = Self;
 
     fn start(&self) -> Self::Position {

--- a/src/value_ref.rs
+++ b/src/value_ref.rs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 Rishabh Dwivedi (rishabhdwivedi17@gmail.com)
+
+use std::ops::Deref;
+
+/// Proxy Reference to temporary value.
+pub struct ValueRef<T> {
+    val: T,
+}
+
+impl<T> Deref for ValueRef<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.val
+    }
+}

--- a/src/value_ref.rs
+++ b/src/value_ref.rs
@@ -8,6 +8,12 @@ pub struct ValueRef<T> {
     val: T,
 }
 
+impl<T> ValueRef<T> {
+    pub fn new(val: T) -> Self {
+        ValueRef { val }
+    }
+}
+
 impl<T> Deref for ValueRef<T> {
     type Target = T;
 

--- a/tests/collection_default_test.rs
+++ b/tests/collection_default_test.rs
@@ -18,6 +18,11 @@ pub mod tests {
 
             type Element = i32;
 
+            type ElementRef<'a>
+                = &'a i32
+            where
+                Self: 'a;
+
             type Whole = Self;
 
             fn start(&self) -> Self::Position {

--- a/tests/for_each_test.rs
+++ b/tests/for_each_test.rs
@@ -19,4 +19,12 @@ pub mod tests {
         arr.for_each_mut(|e| *e += 1);
         assert_eq!(arr, [2, 3, 4]);
     }
+
+    #[test]
+    fn lazy_for_each() {
+        let mut sum = 0;
+        let arr = 1..=3;
+        arr.lazy_for_each(|e| sum += e);
+        assert_eq!(sum, 6);
+    }
 }

--- a/tests/iterable_test.rs
+++ b/tests/iterable_test.rs
@@ -9,7 +9,7 @@ pub mod tests {
     fn sum_by_iteration() {
         let arr = [1, 2, 3];
         let mut sum = 0;
-        for i in Collection::iter(&arr) {
+        for i in CollectionExt::iter(&arr) {
             sum += i;
         }
         assert_eq!(sum, 6);

--- a/tests/iterable_test.rs
+++ b/tests/iterable_test.rs
@@ -14,4 +14,14 @@ pub mod tests {
         }
         assert_eq!(sum, 6);
     }
+
+    #[test]
+    fn sum_by_lazy_iteration() {
+        let arr = 1..=3;
+        let mut sum = 0;
+        for i in arr.lazy_iter() {
+            sum += i;
+        }
+        assert_eq!(sum, 6);
+    }
 }

--- a/tests/range_test.rs
+++ b/tests/range_test.rs
@@ -16,6 +16,7 @@ pub mod tests {
         assert_eq!(arr.prior_n(2, 2), 0);
         assert_eq!(arr.compute_at(&2), 2);
         assert_eq!(*(&arr.at(&2) as &i32), 2);
+        assert!(arr.all().equals(&[1, 2, 3, 4]));
     }
 
     #[test]
@@ -29,5 +30,6 @@ pub mod tests {
         assert_eq!(arr.prior_n(2, 2), 0);
         assert_eq!(arr.compute_at(&2), 2);
         assert_eq!(*(&arr.at(&2) as &i32), 2);
+        assert!(arr.all().equals(&[1, 2, 3, 4, 5]));
     }
 }

--- a/tests/range_test.rs
+++ b/tests/range_test.rs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 Rishabh Dwivedi (rishabhdwivedi17@gmail.com)
+
+#[cfg(test)]
+pub mod tests {
+    use stl::*;
+
+    #[test]
+    fn range() {
+        let arr = 1..5;
+        assert_eq!(Collection::start(&arr), 1);
+        assert_eq!(Collection::end(&arr), 5);
+        assert_eq!(arr.next(2), 3);
+        assert_eq!(arr.next_n(2, 2), 4);
+        assert_eq!(arr.prior(2), 1);
+        assert_eq!(arr.prior_n(2, 2), 0);
+        assert_eq!(arr.compute_at(&2), 2);
+        assert_eq!(*(&arr.at(&2) as &i32), 2);
+    }
+
+    #[test]
+    fn range_inclusive() {
+        let arr = 1..=5;
+        assert_eq!(Collection::start(&arr), 1);
+        assert_eq!(Collection::end(&arr), 6);
+        assert_eq!(arr.next(2), 3);
+        assert_eq!(arr.next_n(2, 2), 4);
+        assert_eq!(arr.prior(2), 1);
+        assert_eq!(arr.prior_n(2, 2), 0);
+        assert_eq!(arr.compute_at(&2), 2);
+        assert_eq!(*(&arr.at(&2) as &i32), 2);
+    }
+}

--- a/tests/slice_hierarchy.rs
+++ b/tests/slice_hierarchy.rs
@@ -19,6 +19,11 @@ pub mod tests {
 
             type Element = i32;
 
+            type ElementRef<'a>
+                = &'a i32
+            where
+                Self: 'a;
+
             type Whole = Self;
 
             fn start(&self) -> Self::Position {

--- a/tests/slice_mut_test.rs
+++ b/tests/slice_mut_test.rs
@@ -163,4 +163,10 @@ pub mod tests {
         assert_eq!(e, None);
         assert!(s.equals(&[]));
     }
+
+    #[test]
+    fn compute_at() {
+        let arr = 0..=3;
+        assert_eq!(arr.all().compute_at(&0), 0);
+    }
 }

--- a/tests/slice_test.rs
+++ b/tests/slice_test.rs
@@ -157,4 +157,19 @@ pub mod tests {
         let arr = 0..=3;
         assert_eq!(arr.all().compute_at(&0), 0);
     }
+
+    #[test]
+    fn lazy_pop_first() {
+        let arr = 0..=3;
+        let mut s = arr.all();
+        let e = s.lazy_pop_first();
+        assert_eq!(e, Some(0));
+        assert!(s.equals(&[1, 2, 3]));
+
+        let arr = 0..0;
+        let mut s = arr.all();
+        let e = s.lazy_pop_first();
+        assert_eq!(e, None);
+        assert!(s.equals(&[]));
+    }
 }

--- a/tests/slice_test.rs
+++ b/tests/slice_test.rs
@@ -151,4 +151,10 @@ pub mod tests {
         assert_eq!(e, None);
         assert!(s.equals(&[]));
     }
+
+    #[test]
+    fn compute_at() {
+        let arr = 0..=3;
+        assert_eq!(arr.all().compute_at(&0), 0);
+    }
 }


### PR DESCRIPTION
# Lazy Collections
A discussion thread on lazy collections is present at [hylo-lang/discussions#1668](https://github.com/orgs/hylo-lang/discussions/1668). I believe that there are 2 axes of laziness:
1. Compute positions/boundaries lazily
2. Compute elements at any position lazily

In the above thread I provided ideas why I think we don't require point 1 for our collection model. So, this PR addresses the point 2 i.e., compute elements at any position lazily.

## Design
**Def**: A `LazyCollection` is a `Collection` which computes element at time of element access rather than obtaining it from memory.

Thus a `LazyCollection` have all the capabilities of `Collection` but we want to take advantage of the fact that element is being lazily computed at element access. Thus `LazyCollection` would provide extra functionality over `Collection`.

### Unification of in-memory elements and computed elements
Our current collection model doesn't follow the above definition of `LazyCollection`. In current `Collection` trait, `.at()` method returns references that strictly binds `Collection` trait to elements in memory.

Swift unifies the same with abstraction of "yielding" an element. So, swift's collection model doesn't distinguish if element was present in memory or is being lazily computed. Taking inspiration from swift, `Collection` now returns `ElementRef` that is ref-like type to `Element`. This is proxy reference technique. We can't do better in rust currently.

### LazyCollection functionalities
LazyCollection just exposes `compute_at()` method that returns value. If we think Algorithms like `move_elements` are applicable for only `LazyCollection` not `Collection`.

## Motivation
Few days back I wrote this code for a leetcode problem in swift:
```swift
func minimizedMaximum(_ n: Int, _ quantities: [Int]) -> Int {
  let max = quantities.max()!
  let arr = 1...max
  let i = arr.partitioningIndex {
    minShopsRequired(products: quantities, with: $0) <= n
  }
  return arr[i]
}
```
I wanted to write the similar thing using rs-stl.... however I realized that I can't model `1..=max` as Collection as `1..=max` can't return by value on `at()` call. Observing that lazy computation of element has nothing to do with `partitioningIndex` algorithm. Thus, `partitioningIndex` algorithm should be same for collection and lazy collections i.e., no 2 implementations.

So, I think fixing `Collection` was a necessary problem. This also makes the goal for `LazyCollection` more clearer according to me.

cc: @dabrahams 