### PR TITLE
feat: Predicate<T> and BinaryPredicate<T, U>

### DIFF
--- a/src/algo/collection_ext/mod.rs
+++ b/src/algo/collection_ext/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2025 Rishabh Dwivedi (rishabhdwivedi17@gmail.com)
 
-use crate::{Collection, Slice};
+use crate::{Collection, Predicate, Slice};
 
 pub trait CollectionExt: Collection {
     /// Returns the first element, or nil if `self` is empty.
@@ -164,7 +164,7 @@ pub trait CollectionExt: Collection {
     /// ```
     fn find_if<Pred>(&self, pred: Pred) -> Self::Position
     where
-        Pred: Fn(&Self::Element) -> bool,
+        Pred: Predicate<Self::Element>,
     {
         let mut rest = self.all();
         while let Some(x) = rest.first() {

--- a/src/core.rs
+++ b/src/core.rs
@@ -20,6 +20,22 @@ impl<T> SemiRegular for T where T: Eq {}
 pub trait Regular: SemiRegular + Clone {}
 impl<T> Regular for T where T: SemiRegular + Clone {}
 
+/// A `Predicate<T>` is a "cheap" to copy function that accepts
+/// T by reference and returns bool.
+///
+/// Because `Predicate<T>` is cheap to copy, functions should accept
+/// predicates by value.
+pub trait Predicate<T>: Fn(&T) -> bool + Copy {}
+impl<T, F> Predicate<T> for F where F: Fn(&T) -> bool + Copy {}
+
+/// A `BinaryPredicate<T, U>` is a "cheap" to copy function that accepts
+/// `T` and `U` by reference and returns bool.
+///
+/// Because `BinaryPredicate<T, U>` is cheap to copy,
+/// functions should accept binary predicates by value.
+pub trait BinaryPredicate<T, U>: Fn(&T, &U) -> bool + Copy {}
+impl<T, U, F> BinaryPredicate<T, U> for F where F: Fn(&T, &U) -> bool + Copy {}
+
 /// Models a multi-pass linear sequence of elements.
 ///
 /// Representation:

--- a/tests/find_test.rs
+++ b/tests/find_test.rs
@@ -10,6 +10,11 @@ pub mod tests {
         let arr = [1, 2, 3, 4];
         let i = arr.find_if(|x| *x == 2);
         assert_eq!(i, 1);
+
+        let arr = ["Hello".to_string(), "Test".to_string()];
+        let to_find = "Test".to_string();
+        let i = arr.find_if(|x| *x == to_find);
+        assert_eq!(i, 1);
     }
 
     #[test]


### PR DESCRIPTION
Predicate and BinaryPredicate are common function we use across generic programming. Formalising it with trait is an useful investment.

Also for performance purposes, I decided to commit to Predicate and BinaryPredicate to be `Copy`. Thus its fine to pass predicates by value around and they are cheap to copy to its fine to copy them while composing algorithms.