### PR TITLE
Improve situations of slice algorithms

### DIFF
--- a/src/algo/collection_ext/mod.rs
+++ b/src/algo/collection_ext/mod.rs
@@ -145,10 +145,10 @@ pub trait CollectionExt: Collection {
     /// use stl::*;
     ///
     /// let arr = [1, 3, 5, 2, 4, 7];
-    /// let s = arr.drop_while(|x| x % 2 == 1);
+    /// let s = arr.dropping_while(|x| x % 2 == 1);
     /// assert!(s.equals(&[2, 4, 7]));
     /// ```
-    fn drop_while<F>(&self, mut predicate: F) -> Slice<'_, Self::Whole>
+    fn dropping_while<F>(&self, mut predicate: F) -> Slice<'_, Self::Whole>
     where
         F: FnMut(&Self::Element) -> bool,
     {
@@ -169,10 +169,10 @@ pub trait CollectionExt: Collection {
     /// use stl::*;
     ///
     /// let arr = [1, 2, 3, 4, 5];
-    /// let s = arr.drop(3);
+    /// let s = arr.dropping_prefix(3);
     /// assert!(s.equals(&[4, 5]));
     /// ```
-    fn drop(&self, count: usize) -> Slice<'_, Self::Whole> {
+    fn dropping_prefix(&self, count: usize) -> Slice<'_, Self::Whole> {
         let mut start = self.start();
         self.form_next_n_limited_by(&mut start, count, self.end());
         self.suffix_from(start)
@@ -192,10 +192,10 @@ pub trait CollectionExt: Collection {
     /// use stl::*;
     ///
     /// let arr = [1, 2, 3, 4, 5];
-    /// let s = arr.drop_end(3);
+    /// let s = arr.dropping_suffix(3);
     /// assert!(s.equals(&[1, 2]));
     /// ```
-    fn drop_end(&self, count: usize) -> Slice<'_, Self::Whole> {
+    fn dropping_suffix(&self, count: usize) -> Slice<'_, Self::Whole> {
         let n = self.count();
         if count > n {
             return self.prefix_upto(self.start());

--- a/src/algo/reorderable_collection_ext/mod.rs
+++ b/src/algo/reorderable_collection_ext/mod.rs
@@ -142,10 +142,10 @@ where
     /// use stl::*;
     ///
     /// let mut arr = [1, 3, 5, 2, 4, 7];
-    /// let s = arr.drop_while_mut(|x| x % 2 == 1);
+    /// let s = arr.dropping_while_mut(|x| x % 2 == 1);
     /// assert!(s.equals(&[2, 4, 7]));
     /// ```
-    fn drop_while_mut<F>(
+    fn dropping_while_mut<F>(
         &mut self,
         mut predicate: F,
     ) -> SliceMut<'_, Self::Whole>
@@ -168,11 +168,14 @@ where
     /// ```rust
     /// use stl::*;
     ///
-    /// let arr = [1, 2, 3, 4, 5];
-    /// let s = arr.drop(3);
+    /// let mut arr = [1, 2, 3, 4, 5];
+    /// let s = arr.dropping_prefix_mut(3);
     /// assert!(s.equals(&[4, 5]));
     /// ```
-    fn drop_mut(&mut self, count: usize) -> SliceMut<'_, Self::Whole> {
+    fn dropping_prefix_mut(
+        &mut self,
+        count: usize,
+    ) -> SliceMut<'_, Self::Whole> {
         let mut start = self.start();
         self.form_next_n_limited_by(&mut start, count, self.end());
         self.suffix_from_mut(start)
@@ -191,11 +194,14 @@ where
     /// ```rust
     /// use stl::*;
     ///
-    /// let arr = [1, 2, 3, 4, 5];
-    /// let s = arr.drop_end(3);
+    /// let mut arr = [1, 2, 3, 4, 5];
+    /// let s = arr.dropping_suffix_mut(3);
     /// assert!(s.equals(&[1, 2]));
     /// ```
-    fn drop_end_mut(&mut self, count: usize) -> SliceMut<'_, Self::Whole> {
+    fn dropping_suffix_mut(
+        &mut self,
+        count: usize,
+    ) -> SliceMut<'_, Self::Whole> {
         let n = self.count();
         if count > n {
             return self.prefix_upto_mut(self.start());

--- a/src/iterators/split_evenly_iterator.rs
+++ b/src/iterators/split_evenly_iterator.rs
@@ -55,7 +55,7 @@ where
             self.rest.end(),
         );
 
-        Some(self.rest.trim_prefix_upto(next_pos))
+        Some(self.rest.pop_prefix_upto(next_pos))
     }
 }
 
@@ -118,7 +118,7 @@ where
             self.rest.end(),
         );
 
-        Some(self.rest.trim_prefix_upto(next_pos))
+        Some(self.rest.pop_prefix_upto(next_pos))
     }
 }
 

--- a/src/iterators/split_iterator.rs
+++ b/src/iterators/split_iterator.rs
@@ -43,7 +43,7 @@ where
             return None;
         }
         let p = self.rest.first_position_where(self.predicate.clone());
-        let res = self.rest.trim_prefix_upto(p);
+        let res = self.rest.pop_prefix_upto(p);
         self.rest.drop_first();
         Some(res)
     }
@@ -90,7 +90,7 @@ where
             return None;
         }
         let p = self.rest.first_position_where(self.predicate.clone());
-        let res = self.rest.trim_prefix_upto(p);
+        let res = self.rest.pop_prefix_upto(p);
         self.rest.drop_first();
         Some(res)
     }

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -2,7 +2,8 @@
 // Copyright (c) 2025 Rishabh Dwivedi (rishabhdwivedi17@gmail.com)
 
 use crate::{
-    BidirectionalCollection, Collection, LazyCollection, RandomAccessCollection,
+    BidirectionalCollection, Collection, CollectionExt, LazyCollection,
+    RandomAccessCollection,
 };
 
 /// A contiguous sub-collection of a collection.
@@ -71,6 +72,593 @@ where
     }
 }
 
+/// Dropping algorithms
+impl<Whole> Slice<'_, Whole>
+where
+    Whole: Collection<Whole = Whole>,
+{
+    /// Removes the first element if non-empty and returns true; returns false otherwise.
+    ///
+    /// # Example
+    /// ```rust
+    /// use stl::*;
+    ///
+    /// let arr = [1, 2, 3];
+    /// let mut s = arr.full();
+    /// assert!(s.drop_first());
+    /// assert!(s.equals(&[2, 3]));
+    /// ```
+    pub fn drop_first(&mut self) -> bool {
+        if self.from == self.to {
+            false
+        } else {
+            self._whole.form_next(&mut self.from);
+            true
+        }
+    }
+
+    /// Removes the last element if non-empty and returns true; returns false otherwise.
+    ///
+    /// # Example
+    /// ```rust
+    /// use stl::*;
+    ///
+    /// let arr = [1, 2, 3];
+    /// let mut s = arr.full();
+    /// assert!(s.drop_last());
+    /// assert!(s.equals(&[1, 2]));
+    /// ```
+    pub fn drop_last(&mut self) -> bool
+    where
+        Whole: BidirectionalCollection,
+    {
+        if self.from == self.to {
+            false
+        } else {
+            self._whole.form_prior(&mut self.to);
+            true
+        }
+    }
+
+    /// Drops prefix upto specified maximum length.
+    ///
+    /// # Postcondition
+    ///   - If `max_length > self.count()`, make `self` empty.
+    ///
+    /// # Complexity
+    ///   - O(1) for RandomAccessCollection;
+    ///   - O(n) otherwise, where `n == self.count()`.
+    ///
+    /// # Example
+    /// ```rust
+    /// use stl::*;
+    ///
+    /// let arr = [0, 1, 2, 3];
+    /// let mut s = arr.full();
+    /// s.drop_prefix(2);
+    /// assert!(s.equals(&[2, 3]));
+    /// ```
+    pub fn drop_prefix(&mut self, max_length: usize) {
+        let mut new_from = self.from.clone();
+        self._whole.form_next_n_limited_by(
+            &mut new_from,
+            max_length,
+            self.to.clone(),
+        );
+        self.from = new_from;
+    }
+
+    /// Drops the prefix of slice upto given `position`.
+    ///
+    /// # Precondition
+    ///   - `position` is valid position in `self`.
+    ///
+    /// # Example
+    /// ```rust
+    /// use stl::*;
+    ///
+    /// let arr = [0, 1, 2, 3];
+    /// let mut s = arr.full();
+    /// s.drop_prefix_upto(2);
+    /// assert!(s.equals(&[2, 3]));
+    /// ```
+    pub fn drop_prefix_upto(&mut self, position: Whole::Position) {
+        self.assert_bounds_check_slice(&position);
+        self.from = position;
+    }
+
+    /// Drops the prefix of slice till and including given `position`.
+    ///
+    /// # Precondition
+    ///   - `position` is valid position in `self`.
+    ///   - `position != self.end()`
+    ///
+    /// # Example
+    /// ```rust
+    /// use stl::*;
+    ///
+    /// let arr = [0, 1, 2, 3];
+    /// let mut s = arr.full();
+    /// s.drop_prefix_through(2);
+    /// assert!(s.equals(&[3]));
+    /// ```
+    pub fn drop_prefix_through(&mut self, position: Whole::Position) {
+        self.assert_bounds_check_read(&position);
+        self.from = self._whole.next(position);
+    }
+
+    /// Drops the element of `self` while the elements satisfy given `predicate`.
+    ///
+    /// # Complexity
+    ///   - O(n) where `n == self.count()`.
+    ///
+    /// # Example
+    /// ```rust
+    /// use stl::*;
+    ///
+    /// let arr = [0, 1, 2, 3];
+    /// let mut s = arr.full();
+    /// s.drop_while(|x| *x < 2);
+    /// assert!(s.equals(&[2, 3]));
+    /// ```
+    pub fn drop_while<Pred>(&mut self, mut predicate: Pred)
+    where
+        Pred: FnMut(&Whole::Element) -> bool,
+    {
+        self.from = self.first_position_where(|e| !predicate(e));
+    }
+
+    /// Drops suffix upto specified maximum length.
+    ///
+    /// # Postcondition
+    ///   - If `max_length > self.count()`, make `self` empty.
+    ///
+    /// # Complexity
+    ///   - O(n), where `n == self.count()`.
+    ///
+    /// # Example
+    /// ```rust
+    /// use stl::*;
+    ///
+    /// let arr = [0, 1, 2, 3];
+    /// let mut s = arr.full();
+    /// s.drop_suffix(2);
+    /// assert!(s.equals(&[0, 1]));
+    /// ```
+    pub fn drop_suffix(&mut self, max_length: usize) {
+        let n = self.count();
+        if max_length > n {
+            self.to = self.from.clone()
+        } else {
+            self.to = self.next_n(self.start(), n - max_length)
+        }
+    }
+
+    /// Drops suffix from given `position`.
+    ///
+    /// # Precondition
+    ///   - `position` is a valid position in self.
+    ///
+    /// # Complexity
+    ///   - O(n), where `n == self.count()`.
+    ///
+    /// # Example
+    /// ```rust
+    /// use stl::*;
+    ///
+    /// let arr = [0, 1, 2, 3];
+    /// let mut s = arr.full();
+    /// s.drop_suffix_from(2);
+    /// assert!(s.equals(&[0, 1]));
+    /// ```
+    pub fn drop_suffix_from(&mut self, position: Whole::Position) {
+        self.assert_bounds_check_slice(&position);
+        self.to = position;
+    }
+}
+
+/// Pop algorithms.
+impl<'a, Whole> Slice<'a, Whole>
+where
+    Whole: Collection<Whole = Whole>,
+{
+    /// Removes and returns the first element if non-empty; returns None otherwise.
+    ///
+    /// # Example
+    /// ```rust
+    /// use stl::*;
+    ///
+    /// let arr = [1, 2, 3];
+    /// let mut s = arr.full();
+    /// let first = s.pop_first().unwrap();
+    /// assert_eq!(*first, 1);
+    /// assert!(s.equals(&[2, 3]));
+    /// ```
+    pub fn pop_first(&mut self) -> Option<Whole::ElementRef<'a>> {
+        if self.from == self.to {
+            None
+        } else {
+            let e = Some(self._whole.at(&self.from));
+            self._whole.form_next(&mut self.from);
+            e
+        }
+    }
+
+    /// Removes and returns the first element and its position if non-empty; returns None otherwise.
+    ///
+    /// # Example
+    /// ```rust
+    /// use stl::*;
+    ///
+    /// let arr = [1, 2, 3];
+    /// let mut s = arr.full();
+    /// let (first_pos, first) = s.pop_first_with_pos().unwrap();
+    /// assert_eq!(first_pos, 0);
+    /// assert_eq!(*first, 1);
+    /// assert!(s.equals(&[2, 3]));
+    /// ```
+    pub fn pop_first_with_pos(
+        &mut self,
+    ) -> Option<(Whole::Position, Whole::ElementRef<'a>)> {
+        if self.from == self.to {
+            None
+        } else {
+            let e = self._whole.at(&self.from);
+            let p = self.from.clone();
+            self._whole.form_next(&mut self.from);
+            Some((p, e))
+        }
+    }
+
+    /// Removes and returns the last element if non-empty; returns None otherwise.
+    ///
+    /// # Example
+    /// ```rust
+    /// use stl::*;
+    ///
+    /// let arr = [1, 2, 3];
+    /// let mut s = arr.full();
+    /// let last = s.pop_last().unwrap();
+    /// assert_eq!(*last, 3);
+    /// assert!(s.equals(&[1, 2]));
+    /// ```
+    pub fn pop_last(&mut self) -> Option<Whole::ElementRef<'a>>
+    where
+        Whole: BidirectionalCollection,
+    {
+        if self.from == self.to {
+            None
+        } else {
+            let ele_pos = self._whole.prior(self.to.clone());
+            let e = Some(self._whole.at(&ele_pos));
+            self._whole.form_prior(&mut self.to);
+            e
+        }
+    }
+
+    /// Removes and returns the last element and its position if non-empty; returns None otherwise.
+    ///
+    /// # Example
+    /// ```rust
+    /// use stl::*;
+    ///
+    /// let arr = [1, 2, 3];
+    /// let mut s = arr.full();
+    /// let (last_pos, last) = s.pop_last_with_pos().unwrap();
+    /// assert_eq!(last_pos, 2);
+    /// assert_eq!(*last, 3);
+    /// assert!(s.equals(&[1, 2]));
+    /// ```
+    pub fn pop_last_with_pos(
+        &mut self,
+    ) -> Option<(Whole::Position, Whole::ElementRef<'a>)>
+    where
+        Whole: BidirectionalCollection,
+    {
+        if self.from == self.to {
+            None
+        } else {
+            let ele_pos = self._whole.prior(self.to.clone());
+            let e = self._whole.at(&ele_pos);
+            self._whole.form_prior(&mut self.to);
+            Some((ele_pos, e))
+        }
+    }
+
+    /// Removes and returns prefix upto specified maximum length.
+    ///
+    /// # Postcondition
+    ///   - If `max_length > self.count()`, make `self` empty and return the full slice as result.
+    ///
+    /// # Complexity
+    ///   - O(1) for RandomAccessCollection;
+    ///   - O(n) otherwise, where `n == self.count()`.
+    ///
+    /// # Examples
+    /// ```rust
+    /// use stl::*;
+    ///
+    /// let arr = [0, 1, 2, 3];
+    /// let mut s = arr.full();
+    /// let prefix = s.pop_prefix(2);
+    /// assert!(prefix.equals(&[0, 1]));
+    /// assert!(s.equals(&[2, 3]));
+    /// ```
+    pub fn pop_prefix(&mut self, max_length: usize) -> Self {
+        let old_from = self.from.clone();
+        let mut new_from = self.from.clone();
+        self._whole.form_next_n_limited_by(
+            &mut new_from,
+            max_length,
+            self.to.clone(),
+        );
+        self.from = new_from;
+        Self {
+            _whole: self._whole,
+            from: old_from,
+            to: self.from.clone(),
+        }
+    }
+
+    /// Removes and returns the prefix slice upto given `position`.
+    ///
+    /// # Precondition
+    ///   - `position` is valid position in `self`.
+    ///
+    /// # Example
+    /// ```rust
+    /// use stl::*;
+    ///
+    /// let arr = [0, 1, 2, 3];
+    /// let mut s = arr.full();
+    /// let prefix = s.pop_prefix_upto(2);
+    /// assert!(prefix.equals(&[0, 1]));
+    /// assert!(s.equals(&[2, 3]));
+    /// ```
+    pub fn pop_prefix_upto(&mut self, position: Whole::Position) -> Self {
+        self.assert_bounds_check_slice(&position);
+        let prefix = Self {
+            _whole: self._whole,
+            from: self.from.clone(),
+            to: position.clone(),
+        };
+        self.from = position;
+        prefix
+    }
+
+    /// Removes and returns the prefix till and including given `position`.
+    ///
+    /// # Precondition
+    ///   - `position` is valid position in `self`.
+    ///   - `position != self.end()`
+    ///
+    /// # Example
+    /// ```rust
+    /// use stl::*;
+    ///
+    /// let arr = [0, 1, 2, 3];
+    /// let mut s = arr.full();
+    /// let prefix = s.pop_prefix_through(2);
+    /// assert!(prefix.equals(&[0, 1, 2]));
+    /// assert!(s.equals(&[3]));
+    /// ```
+    pub fn pop_prefix_through(&mut self, position: Whole::Position) -> Self {
+        self.assert_bounds_check_read(&position);
+        let old_from = self.from.clone();
+        self.from = self._whole.next(position);
+        Self {
+            _whole: self._whole,
+            from: old_from,
+            to: self.from.clone(),
+        }
+    }
+
+    /// Removes and returns  the element of `self` till the first element satisfies `predicate` as a slice.
+    ///
+    /// # Complexity
+    ///   - O(n) where `n == self.count()`.
+    ///
+    /// # Example
+    /// ```rust
+    /// use stl::*;
+    ///
+    /// let arr = [0, 1, 2, 3];
+    /// let mut s = arr.full();
+    /// let prefix = s.pop_while(|x| *x < 2);
+    /// assert!(prefix.equals(&[0, 1]));
+    /// assert!(s.equals(&[2, 3]));
+    /// ```
+    pub fn pop_while<Pred>(&mut self, mut predicate: Pred) -> Self
+    where
+        Pred: FnMut(&Whole::Element) -> bool,
+    {
+        let p = self.first_position_where(|e| !predicate(e));
+        let res = Slice {
+            _whole: self._whole,
+            from: self.from.clone(),
+            to: p.clone(),
+        };
+        self.from = p;
+        res
+    }
+
+    /// Removes and returns suffix upto specified maximum length.
+    ///
+    /// # Postcondition
+    ///   - If `max_length > self.count()`, make `self` empty and returns the
+    ///     full slice as suffix.
+    ///
+    /// # Complexity
+    ///   - O(n), where `n == self.count()`.
+    ///
+    /// # Example
+    /// ```rust
+    /// use stl::*;
+    ///
+    /// let arr = [0, 1, 2, 3];
+    /// let mut s = arr.full();
+    /// let suffix = s.pop_suffix(2);
+    /// assert!(s.equals(&[0, 1]));
+    /// assert!(suffix.equals(&[2, 3]));
+    /// ```
+    pub fn pop_suffix(&mut self, max_length: usize) -> Self {
+        let n = self.count();
+        let old_to = self.to.clone();
+        if max_length > n {
+            self.to = self.from.clone()
+        } else {
+            self.to = self.next_n(self.start(), n - max_length)
+        }
+        Self {
+            _whole: self._whole,
+            from: self.to.clone(),
+            to: old_to,
+        }
+    }
+
+    /// Removes and returns suffix from given `position`.
+    ///
+    /// # Precondition
+    ///   - `position` is a valid position in self.
+    ///
+    /// # Complexity
+    ///   - O(n), where `n == self.count()`.
+    ///
+    /// # Example
+    /// ```rust
+    /// use stl::*;
+    ///
+    /// let arr = [0, 1, 2, 3];
+    /// let mut s = arr.full();
+    /// let suffix = s.pop_suffix_from(2);
+    /// assert!(s.equals(&[0, 1]));
+    /// assert!(suffix.equals(&[2, 3]));
+    /// ```
+    pub fn pop_suffix_from(&mut self, position: Whole::Position) -> Self {
+        self.assert_bounds_check_slice(&position);
+        let old_to = self.to.clone();
+        self.to = position;
+        Self {
+            _whole: self._whole,
+            from: self.to.clone(),
+            to: old_to,
+        }
+    }
+}
+
+/// Pop algorithms for `LazyCollection`.
+impl<'a, Whole> Slice<'a, Whole>
+where
+    Whole: LazyCollection<Whole = Whole>,
+{
+    /// Removes and returns the lazily computed first element if non-empty;
+    /// returns None otherwise.
+    ///
+    /// # Example
+    /// ```rust
+    /// use stl::*;
+    ///
+    /// let arr = 1..=3;
+    /// let mut s = arr.full();
+    /// let first = s.lazy_pop_first().unwrap();
+    /// assert_eq!(first, 1);
+    /// assert!(s.equals(&[2, 3]));
+    /// ```
+    pub fn lazy_pop_first(&mut self) -> Option<Whole::Element> {
+        if self.from == self.to {
+            None
+        } else {
+            let e = Some(self._whole.compute_at(&self.from));
+            self._whole.form_next(&mut self.from);
+            e
+        }
+    }
+
+    /// Removes and returns the lazily computed first element and its position if non-empty;
+    /// returns None otherwise.
+    ///
+    /// # Example
+    /// ```rust
+    /// use stl::*;
+    ///
+    /// let arr = 1..=3;
+    /// let mut s = arr.full();
+    /// let (first_pos, first) = s.lazy_pop_first_with_pos().unwrap();
+    /// assert_eq!(first_pos, 1);
+    /// assert_eq!(first, 1);
+    /// assert!(s.equals(&[2, 3]));
+    /// ```
+    pub fn lazy_pop_first_with_pos(
+        &mut self,
+    ) -> Option<(Whole::Position, Whole::Element)> {
+        if self.from == self.to {
+            None
+        } else {
+            let e = self._whole.compute_at(&self.from);
+            let p = self.from.clone();
+            self._whole.form_next(&mut self.from);
+            Some((p, e))
+        }
+    }
+
+    /// Removes and returns the lazily computed last element if non-empty;
+    /// returns None otherwise.
+    ///
+    /// # Example
+    /// ```rust
+    /// use stl::*;
+    ///
+    /// let arr = 1..=3;
+    /// let mut s = arr.full();
+    /// let last = s.lazy_pop_last().unwrap();
+    /// assert_eq!(last, 3);
+    /// assert!(s.equals(&[1, 2]));
+    /// ```
+    pub fn lazy_pop_last(&mut self) -> Option<Whole::Element>
+    where
+        Whole: BidirectionalCollection,
+    {
+        if self.from == self.to {
+            None
+        } else {
+            let ele_pos = self._whole.prior(self.to.clone());
+            let e = Some(self._whole.compute_at(&ele_pos));
+            self._whole.form_prior(&mut self.to);
+            e
+        }
+    }
+
+    /// Removes and returns the lazily computed last element and its position if non-empty;
+    /// returns None otherwise.
+    ///
+    /// # Example
+    /// ```rust
+    /// use stl::*;
+    ///
+    /// let arr = 1..=3;
+    /// let mut s = arr.full();
+    /// let (last_pos, last) = s.lazy_pop_last_with_pos().unwrap();
+    /// assert_eq!(last_pos, 3);
+    /// assert_eq!(last, 3);
+    /// assert!(s.equals(&[1, 2]));
+    /// ```
+    pub fn lazy_pop_last_with_pos(
+        &mut self,
+    ) -> Option<(Whole::Position, Whole::Element)>
+    where
+        Whole: BidirectionalCollection,
+    {
+        if self.from == self.to {
+            None
+        } else {
+            let ele_pos = self._whole.prior(self.to.clone());
+            let e = self._whole.compute_at(&ele_pos);
+            self._whole.form_prior(&mut self.to);
+            Some((ele_pos, e))
+        }
+    }
+}
+
 /// Splitting algorithms.
 impl<Whole> Slice<'_, Whole>
 where
@@ -93,18 +681,6 @@ where
         (prefix, suffix)
     }
 
-    /// Trims the prefix of slice upto given `position` and returns the prefix.
-    pub fn trim_prefix_upto(&mut self, position: Whole::Position) -> Self {
-        self.assert_bounds_check_slice(&position);
-        let prefix = Self {
-            _whole: self._whole,
-            from: self.from.clone(),
-            to: position.clone(),
-        };
-        self.from = position;
-        prefix
-    }
-
     /// Splits slice into 2 parts where first part would have `[from, position]`
     /// and second part would have `[next(position), to)`.
     ///
@@ -113,164 +689,6 @@ where
     pub fn split_after(self, mut position: Whole::Position) -> (Self, Self) {
         self.form_next(&mut position);
         self.split_at(position)
-    }
-
-    /// Trims the prefix of slice through given `position`(inclusive) and returns the prefix.
-    ///
-    /// # Precondition
-    ///   - `position != self.end()`.
-    pub fn trim_prefix_through(
-        &mut self,
-        mut position: Whole::Position,
-    ) -> Self {
-        self.form_next(&mut position);
-        self.trim_prefix_upto(position)
-    }
-}
-
-/// Shrinking Algorithms.
-impl<'a, Whole> Slice<'a, Whole>
-where
-    Whole: Collection<Whole = Whole>,
-{
-    /// Removes and returns the first element and its position if non-empty; returns None otherwise.
-    pub fn pop_first_with_pos(
-        &mut self,
-    ) -> Option<(Whole::Position, Whole::ElementRef<'a>)> {
-        if self.from == self.to {
-            None
-        } else {
-            let e = self._whole.at(&self.from);
-            let p = self.from.clone();
-            self._whole.form_next(&mut self.from);
-            Some((p, e))
-        }
-    }
-
-    /// Removes and returns the first element if non-empty; returns None otherwise.
-    pub fn pop_first(&mut self) -> Option<Whole::ElementRef<'a>> {
-        if self.from == self.to {
-            None
-        } else {
-            let e = Some(self._whole.at(&self.from));
-            self._whole.form_next(&mut self.from);
-            e
-        }
-    }
-
-    /// Removes the first element if non-empty and returns true; returns false otherwise.
-    pub fn drop_first(&mut self) -> bool {
-        if self.from == self.to {
-            false
-        } else {
-            self._whole.form_next(&mut self.from);
-            true
-        }
-    }
-}
-
-/// Shrinking Algorithms for BidirectionalCollection.
-impl<'a, Whole> Slice<'a, Whole>
-where
-    Whole: BidirectionalCollection<Whole = Whole>,
-{
-    /// Removes and returns the last element and its position if non-empty; returns None otherwise.
-    pub fn pop_last_with_pos(
-        &mut self,
-    ) -> Option<(Whole::Position, Whole::ElementRef<'a>)> {
-        if self.from == self.to {
-            None
-        } else {
-            let ele_pos = self._whole.prior(self.to.clone());
-            let e = self._whole.at(&ele_pos);
-            self._whole.form_prior(&mut self.to);
-            Some((ele_pos, e))
-        }
-    }
-
-    /// Removes and returns the last element if non-empty; returns None otherwise.
-    pub fn pop_last(&mut self) -> Option<<Self as Collection>::ElementRef<'a>> {
-        if self.from == self.to {
-            None
-        } else {
-            let ele_pos = self._whole.prior(self.to.clone());
-            let e = Some(self._whole.at(&ele_pos));
-            self._whole.form_prior(&mut self.to);
-            e
-        }
-    }
-
-    /// Removes the last element if non-empty and returns true; returns false otherwise.
-    pub fn drop_last(&mut self) -> bool {
-        if self.from == self.to {
-            false
-        } else {
-            self._whole.form_prior(&mut self.to);
-            true
-        }
-    }
-}
-
-/// Shrinking Algorithms for LazyCollection.
-impl<Whole> Slice<'_, Whole>
-where
-    Whole: LazyCollection<Whole = Whole>,
-{
-    /// Removes and returns the first element and its position if non-empty; returns None otherwise.
-    pub fn lazy_pop_first_with_pos(
-        &mut self,
-    ) -> Option<(Whole::Position, Whole::Element)> {
-        if self.from == self.to {
-            None
-        } else {
-            let e = self._whole.compute_at(&self.from);
-            let p = self.from.clone();
-            self._whole.form_next(&mut self.from);
-            Some((p, e))
-        }
-    }
-
-    /// Removes and returns the "lazily computed" first element if non-empty; returns None otherwise.
-    pub fn lazy_pop_first(&mut self) -> Option<Whole::Element> {
-        if self.from == self.to {
-            None
-        } else {
-            let e = Some(self._whole.compute_at(&self.from));
-            self._whole.form_next(&mut self.from);
-            e
-        }
-    }
-}
-
-/// Shrinking Algorithms for BidirectionalCollection + LazyCollection.
-impl<Whole> Slice<'_, Whole>
-where
-    Whole: BidirectionalCollection<Whole = Whole> + LazyCollection,
-{
-    /// Removes and returns the last element and its position if non-empty; returns None otherwise.
-    pub fn lazy_pop_last_with_pos(
-        &mut self,
-    ) -> Option<(Whole::Position, Whole::Element)> {
-        if self.from == self.to {
-            None
-        } else {
-            let ele_pos = self._whole.prior(self.to.clone());
-            let e = self._whole.compute_at(&ele_pos);
-            self._whole.form_prior(&mut self.to);
-            Some((ele_pos, e))
-        }
-    }
-
-    /// Removes and returns the last element if non-empty; returns None otherwise.
-    pub fn lazy_pop_last(&mut self) -> Option<Whole::Element> {
-        if self.from == self.to {
-            None
-        } else {
-            let ele_pos = self._whole.prior(self.to.clone());
-            let e = Some(self._whole.compute_at(&ele_pos));
-            self._whole.form_prior(&mut self.to);
-            e
-        }
     }
 }
 

--- a/tests/slice_mut_test.rs
+++ b/tests/slice_mut_test.rs
@@ -201,27 +201,29 @@ pub mod tests {
     #[test]
     fn drop_while_mut() {
         let mut arr = [1, 3, 5, 2, 4, 7];
-        assert!(arr.drop_while_mut(|x| x % 2 == 1).equals(&[2, 4, 7]));
-        assert!(arr.drop_while_mut(|x| *x < 10).equals(&[]));
-        assert!(arr.drop_while_mut(|x| *x < 1).equals(&[1, 3, 5, 2, 4, 7]));
+        assert!(arr.dropping_while_mut(|x| x % 2 == 1).equals(&[2, 4, 7]));
+        assert!(arr.dropping_while_mut(|x| *x < 10).equals(&[]));
+        assert!(arr
+            .dropping_while_mut(|x| *x < 1)
+            .equals(&[1, 3, 5, 2, 4, 7]));
     }
 
     #[test]
     fn drop_mut() {
         let mut arr = [1, 3, 5, 2, 4, 7];
-        assert!(arr.drop_mut(3).equals(&[2, 4, 7]));
-        assert!(arr.drop_mut(0).equals(&[1, 3, 5, 2, 4, 7]));
-        assert!(arr.drop_mut(6).equals(&[]));
-        assert!(arr.drop_mut(7).equals(&[]));
+        assert!(arr.dropping_prefix_mut(3).equals(&[2, 4, 7]));
+        assert!(arr.dropping_prefix_mut(0).equals(&[1, 3, 5, 2, 4, 7]));
+        assert!(arr.dropping_prefix_mut(6).equals(&[]));
+        assert!(arr.dropping_prefix_mut(7).equals(&[]));
     }
 
     #[test]
     fn drop_end_mut() {
         let mut arr = [1, 3, 5, 2, 4, 7];
-        assert!(arr.drop_end_mut(3).equals(&[1, 3, 5]));
-        assert!(arr.drop_end_mut(0).equals(&[1, 3, 5, 2, 4, 7]));
-        assert!(arr.drop_end_mut(6).equals(&[]));
-        assert!(arr.drop_end_mut(7).equals(&[]));
+        assert!(arr.dropping_suffix_mut(3).equals(&[1, 3, 5]));
+        assert!(arr.dropping_suffix_mut(0).equals(&[1, 3, 5, 2, 4, 7]));
+        assert!(arr.dropping_suffix_mut(6).equals(&[]));
+        assert!(arr.dropping_suffix_mut(7).equals(&[]));
     }
 
     #[test]
@@ -295,12 +297,12 @@ pub mod tests {
     }
 
     #[test]
-    fn trim_prefix_through() {
+    fn pop_prefix_upto() {
         let mut arr = [1, 2, 3, 4, 5];
         let mut s = arr.full_mut();
-        let prefix = s.trim_prefix_through(2);
-        assert!(s.equals(&[4, 5]));
-        assert!(prefix.equals(&[1, 2, 3]));
+        let prefix = s.pop_prefix_upto(2);
+        assert!(s.equals(&[3, 4, 5]));
+        assert!(prefix.equals(&[1, 2]));
     }
 
     #[test]

--- a/tests/slice_test.rs
+++ b/tests/slice_test.rs
@@ -191,27 +191,27 @@ pub mod tests {
     #[test]
     fn drop_while() {
         let arr = [1, 3, 5, 2, 4, 7];
-        assert!(arr.drop_while(|x| x % 2 == 1).equals(&[2, 4, 7]));
-        assert!(arr.drop_while(|x| *x < 10).equals(&[]));
-        assert!(arr.drop_while(|x| *x < 1).equals(&[1, 3, 5, 2, 4, 7]));
+        assert!(arr.dropping_while(|x| x % 2 == 1).equals(&[2, 4, 7]));
+        assert!(arr.dropping_while(|x| *x < 10).equals(&[]));
+        assert!(arr.dropping_while(|x| *x < 1).equals(&[1, 3, 5, 2, 4, 7]));
     }
 
     #[test]
     fn drop() {
         let arr = [1, 3, 5, 2, 4, 7];
-        assert!(arr.drop(3).equals(&[2, 4, 7]));
-        assert!(arr.drop(0).equals(&[1, 3, 5, 2, 4, 7]));
-        assert!(arr.drop(6).equals(&[]));
-        assert!(arr.drop(7).equals(&[]));
+        assert!(arr.dropping_prefix(3).equals(&[2, 4, 7]));
+        assert!(arr.dropping_prefix(0).equals(&[1, 3, 5, 2, 4, 7]));
+        assert!(arr.dropping_prefix(6).equals(&[]));
+        assert!(arr.dropping_prefix(7).equals(&[]));
     }
 
     #[test]
     fn drop_end() {
         let arr = [1, 3, 5, 2, 4, 7];
-        assert!(arr.drop_end(3).equals(&[1, 3, 5]));
-        assert!(arr.drop_end(0).equals(&[1, 3, 5, 2, 4, 7]));
-        assert!(arr.drop_end(6).equals(&[]));
-        assert!(arr.drop_end(7).equals(&[]));
+        assert!(arr.dropping_suffix(3).equals(&[1, 3, 5]));
+        assert!(arr.dropping_suffix(0).equals(&[1, 3, 5, 2, 4, 7]));
+        assert!(arr.dropping_suffix(6).equals(&[]));
+        assert!(arr.dropping_suffix(7).equals(&[]));
     }
 
     #[test]
@@ -286,10 +286,10 @@ pub mod tests {
     }
 
     #[test]
-    fn trim_prefix_through() {
+    fn pop_prefix_through() {
         let arr = [1, 2, 3, 4, 5];
         let mut s = arr.full();
-        let prefix = s.trim_prefix_through(2);
+        let prefix = s.pop_prefix_through(2);
         assert!(s.equals(&[4, 5]));
         assert!(prefix.equals(&[1, 2, 3]));
     }


### PR DESCRIPTION
Algorithms on collection like `drop` didn't follow swift API guidelines. Also there were so many algorithms possible on slices for dropping, popping things out of it.