### PR TITLE
Fix miri tests of main thread exiting before rayon threads

### DIFF
--- a/src/algo/collection_ext/parallel.rs
+++ b/src/algo/collection_ext/parallel.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2025 Rishabh Dwivedi (rishabhdwivedi17@gmail.com)
 
-use crate::{exec_par, Collection, CollectionExt};
+use rayon_core::ThreadPool;
+
+use crate::{exec_par_on, global_thread_pool, Collection, CollectionExt};
 
 /// Parallel Algorithms for `Collection`.
 pub trait ParallelCollectionExt: Collection {
@@ -10,10 +12,13 @@ pub trait ParallelCollectionExt: Collection {
     /// Finds position of first element in `self` satisfying `pred`. If no such
     /// element exists, returns `self.end()`.
     ///
+    /// Parallel version of `first_position_where` executing on `scheduler`.
+    ///
     /// # Complexity
     ///   - O(n) where `n == self.count()`.
-    fn first_position_where_par<Pred>(
+    fn first_position_where_par_on<Pred>(
         &self,
+        scheduler: &ThreadPool,
         pred: Pred,
     ) -> Option<Self::Position>
     where
@@ -33,11 +38,51 @@ pub trait ParallelCollectionExt: Collection {
             .map(|(slice, pred)| move || slice.first_position_where(pred));
 
         // TODO: implement cancellation.
-        exec_par(parallel_tasks).into_iter().flatten().next()
+        exec_par_on(parallel_tasks, scheduler)
+            .into_iter()
+            .flatten()
+            .next()
+    }
+
+    /// Finds position of first element in `self` satisfying `pred`. If no such
+    /// element exists, returns `self.end()`.
+    ///
+    /// Parallel version of `first_position_where`.
+    ///
+    /// # Complexity
+    ///   - O(n) where `n == self.count()`.
+    fn first_position_where_par<Pred>(
+        &self,
+        pred: Pred,
+    ) -> Option<Self::Position>
+    where
+        Pred: Fn(&Self::Element) -> bool + Clone + Send,
+    {
+        self.first_position_where_par_on(global_thread_pool(), pred)
     }
 
     /// Finds position of first element in `self` equals `e`. If no such element
     /// exists, returns `self.end()`.
+    ///
+    /// Parallel version of `first_position_of` executing on `scheduler`.
+    ///
+    /// # Complexity
+    ///   - O(n) where `n == self.count()`.
+    fn first_position_of_par_on(
+        &self,
+        scheduler: &ThreadPool,
+        e: &Self::Element,
+    ) -> Option<Self::Position>
+    where
+        Self::Element: Eq + Sync, // TODO: is Sync really necessary??
+    {
+        self.first_position_where_par_on(scheduler, |x| x == e)
+    }
+
+    /// Finds position of first element in `self` equals `e`. If no such element
+    /// exists, returns `self.end()`.
+    ///
+    /// Parallel version of `first_position_of`.
     ///
     /// # Complexity
     ///   - O(n) where `n == self.count()`.
@@ -45,17 +90,20 @@ pub trait ParallelCollectionExt: Collection {
     where
         Self::Element: Eq + Sync, // TODO: is Sync really necessary??
     {
-        self.first_position_where_par(|x| x == e)
+        self.first_position_of_par_on(global_thread_pool(), e)
     }
 
     /// Finds position of last element in `self` satisfying `pred`. If no such
     /// element exists, returns `self.end()`.
     ///
+    /// Parallel version of `last_position_where` executing on `scheduler`.
+    ///
     /// # Complexity
     ///   - O(n) where `n == self.count()`.
     /// ```
-    fn last_position_where_par<Pred>(
+    fn last_position_where_par_on<Pred>(
         &self,
+        scheduler: &ThreadPool,
         pred: Pred,
     ) -> Option<Self::Position>
     where
@@ -75,11 +123,52 @@ pub trait ParallelCollectionExt: Collection {
             .map(|(slice, pred)| move || slice.last_position_where(pred));
 
         // TODO: implement cancellation.
-        exec_par(parallel_tasks).into_iter().flatten().last()
+        exec_par_on(parallel_tasks, scheduler)
+            .into_iter()
+            .flatten()
+            .last()
+    }
+
+    /// Finds position of last element in `self` satisfying `pred`. If no such
+    /// element exists, returns `self.end()`.
+    ///
+    /// Parallel version of `last_position_where`.
+    ///
+    /// # Complexity
+    ///   - O(n) where `n == self.count()`.
+    /// ```
+    fn last_position_where_par<Pred>(
+        &self,
+        pred: Pred,
+    ) -> Option<Self::Position>
+    where
+        Pred: Fn(&Self::Element) -> bool + Clone + Send,
+    {
+        self.last_position_where_par_on(global_thread_pool(), pred)
     }
 
     /// Finds position of `last` element equals `e`. If no such element exist,
     /// return `self.end()`.
+    ///
+    /// Parallel version of `last_position_of` executing on `scheduler`.
+    ///
+    /// # Complexity
+    ///   - O(n) where `n == self.count()`.
+    fn last_position_of_par_on(
+        &self,
+        scheduler: &ThreadPool,
+        e: &Self::Element,
+    ) -> Option<Self::Position>
+    where
+        Self::Element: Eq + Sync,
+    {
+        self.last_position_where_par_on(scheduler, |x| x == e)
+    }
+
+    /// Finds position of `last` element equals `e`. If no such element exist,
+    /// return `self.end()`.
+    ///
+    /// Parallel version of `last_position_of`.
     ///
     /// # Complexity
     ///   - O(n) where `n == self.count()`.
@@ -87,16 +176,22 @@ pub trait ParallelCollectionExt: Collection {
     where
         Self::Element: Eq + Sync,
     {
-        self.last_position_where_par(|x| x == e)
+        self.last_position_of_par_on(global_thread_pool(), e)
     }
 
     /*-----------------Predicate Test Algorithms-----------------*/
 
     /// Returns true iff all elements in `self` satisfies `pred`.
     ///
+    /// Parallel version of `all_satisfy` executing on `scheduler`.
+    ///
     /// # Complexity
     ///   - O(n) where `n == self.count()`.
-    fn all_satisfy_par<Pred>(&self, pred: Pred) -> bool
+    fn all_satisfy_par_on<Pred>(
+        &self,
+        scheduler: &ThreadPool,
+        pred: Pred,
+    ) -> bool
     where
         Pred: Fn(&Self::Element) -> bool + Clone + Send,
     {
@@ -114,14 +209,35 @@ pub trait ParallelCollectionExt: Collection {
             .map(|(slice, pred)| move || slice.all_satisfy(pred));
 
         // TODO: implement cancellation.
-        exec_par(parallel_tasks).into_iter().all(|e| e)
+        exec_par_on(parallel_tasks, scheduler)
+            .into_iter()
+            .all(|e| e)
+    }
+
+    /// Returns true iff all elements in `self` satisfies `pred`.
+    ///
+    /// Parallel version of `all_satisfy`.
+    ///
+    /// # Complexity
+    ///   - O(n) where `n == self.count()`.
+    fn all_satisfy_par<Pred>(&self, pred: Pred) -> bool
+    where
+        Pred: Fn(&Self::Element) -> bool + Clone + Send,
+    {
+        self.all_satisfy_par_on(global_thread_pool(), pred)
     }
 
     /// Returns true iff atleast one element in `self` satisfies `pred`.
     ///
+    /// Parallel version of `any_satisfy` executing on `scheduler`.
+    ///
     /// # Complexity
     ///   - O(n) where `n == self.count()`.
-    fn any_satisfy_par<Pred>(&self, pred: Pred) -> bool
+    fn any_satisfy_par_on<Pred>(
+        &self,
+        scheduler: &ThreadPool,
+        pred: Pred,
+    ) -> bool
     where
         Pred: Fn(&Self::Element) -> bool + Clone + Send,
     {
@@ -139,14 +255,35 @@ pub trait ParallelCollectionExt: Collection {
             .map(|(slice, pred)| move || slice.any_satisfy(pred));
 
         // TODO: implement cancellation.
-        exec_par(parallel_tasks).into_iter().any(|e| e)
+        exec_par_on(parallel_tasks, scheduler)
+            .into_iter()
+            .any(|e| e)
+    }
+
+    /// Returns true iff atleast one element in `self` satisfies `pred`.
+    ///
+    /// Parallel version of `any_satisfy`.
+    ///
+    /// # Complexity
+    ///   - O(n) where `n == self.count()`.
+    fn any_satisfy_par<Pred>(&self, pred: Pred) -> bool
+    where
+        Pred: Fn(&Self::Element) -> bool + Clone + Send,
+    {
+        self.any_satisfy_par_on(global_thread_pool(), pred)
     }
 
     /// Returns true iff no element in `self` satisfies `pred`.
     ///
+    /// Parallel version of `none_satisfy` executing on `scheduler`.
+    ///
     /// # Complexity
     ///   - O(n) where `n == self.count()`.
-    fn none_satisfy_par<Pred>(&self, pred: Pred) -> bool
+    fn none_satisfy_par_on<Pred>(
+        &self,
+        scheduler: &ThreadPool,
+        pred: Pred,
+    ) -> bool
     where
         Pred: Fn(&Self::Element) -> bool + Clone + Send,
     {
@@ -164,7 +301,22 @@ pub trait ParallelCollectionExt: Collection {
             .map(|(slice, pred)| move || slice.none_satisfy(pred));
 
         // TODO: implement cancellation.
-        exec_par(parallel_tasks).into_iter().all(|e| e)
+        exec_par_on(parallel_tasks, scheduler)
+            .into_iter()
+            .all(|e| e)
+    }
+
+    /// Returns true iff no element in `self` satisfies `pred`.
+    ///
+    /// Parallel version of `none_satisfy`.
+    ///
+    /// # Complexity
+    ///   - O(n) where `n == self.count()`.
+    fn none_satisfy_par<Pred>(&self, pred: Pred) -> bool
+    where
+        Pred: Fn(&Self::Element) -> bool + Clone + Send,
+    {
+        self.none_satisfy_par_on(global_thread_pool(), pred)
     }
 }
 

--- a/src/algo/collection_ext/parallel.rs
+++ b/src/algo/collection_ext/parallel.rs
@@ -24,14 +24,10 @@ pub trait ParallelCollectionExt: Collection {
     where
         Pred: Fn(&Self::Element) -> bool + Clone + Send,
     {
-        let hardware_concurrency = std::thread::available_parallelism()
-            .map(|n| n.get())
-            .unwrap_or(1);
+        let t = scheduler.current_num_threads();
         let min_elements_per_core = 512;
-        let even_splits = self.splitting_evenly_in_with_min_size(
-            hardware_concurrency,
-            min_elements_per_core,
-        );
+        let even_splits =
+            self.splitting_evenly_in_with_min_size(t, min_elements_per_core);
         let num_splits = even_splits.len();
         let parallel_tasks = even_splits
             .zip(std::iter::repeat_n(pred, num_splits))
@@ -109,14 +105,10 @@ pub trait ParallelCollectionExt: Collection {
     where
         Pred: Fn(&Self::Element) -> bool + Clone + Send,
     {
-        let hardware_concurrency = std::thread::available_parallelism()
-            .map(|n| n.get())
-            .unwrap_or(1);
+        let t = scheduler.current_num_threads();
         let min_elements_per_core = 512;
-        let even_splits = self.splitting_evenly_in_with_min_size(
-            hardware_concurrency,
-            min_elements_per_core,
-        );
+        let even_splits =
+            self.splitting_evenly_in_with_min_size(t, min_elements_per_core);
         let num_splits = even_splits.len();
         let parallel_tasks = even_splits
             .zip(std::iter::repeat_n(pred, num_splits))
@@ -195,14 +187,10 @@ pub trait ParallelCollectionExt: Collection {
     where
         Pred: Fn(&Self::Element) -> bool + Clone + Send,
     {
-        let hardware_concurrency = std::thread::available_parallelism()
-            .map(|n| n.get())
-            .unwrap_or(1);
+        let t = scheduler.current_num_threads();
         let min_elements_per_core = 512;
-        let even_splits = self.splitting_evenly_in_with_min_size(
-            hardware_concurrency,
-            min_elements_per_core,
-        );
+        let even_splits =
+            self.splitting_evenly_in_with_min_size(t, min_elements_per_core);
         let num_splits = even_splits.len();
         let parallel_tasks = even_splits
             .zip(std::iter::repeat_n(pred, num_splits))
@@ -241,14 +229,10 @@ pub trait ParallelCollectionExt: Collection {
     where
         Pred: Fn(&Self::Element) -> bool + Clone + Send,
     {
-        let hardware_concurrency = std::thread::available_parallelism()
-            .map(|n| n.get())
-            .unwrap_or(1);
+        let t = scheduler.current_num_threads();
         let min_elements_per_core = 512;
-        let even_splits = self.splitting_evenly_in_with_min_size(
-            hardware_concurrency,
-            min_elements_per_core,
-        );
+        let even_splits =
+            self.splitting_evenly_in_with_min_size(t, min_elements_per_core);
         let num_splits = even_splits.len();
         let parallel_tasks = even_splits
             .zip(std::iter::repeat_n(pred, num_splits))
@@ -287,14 +271,10 @@ pub trait ParallelCollectionExt: Collection {
     where
         Pred: Fn(&Self::Element) -> bool + Clone + Send,
     {
-        let hardware_concurrency = std::thread::available_parallelism()
-            .map(|n| n.get())
-            .unwrap_or(1);
+        let t = scheduler.current_num_threads();
         let min_elements_per_core = 512;
-        let even_splits = self.splitting_evenly_in_with_min_size(
-            hardware_concurrency,
-            min_elements_per_core,
-        );
+        let even_splits =
+            self.splitting_evenly_in_with_min_size(t, min_elements_per_core);
         let num_splits = even_splits.len();
         let parallel_tasks = even_splits
             .zip(std::iter::repeat_n(pred, num_splits))

--- a/src/algo/collection_ext/parallel.rs
+++ b/src/algo/collection_ext/parallel.rs
@@ -12,7 +12,7 @@ pub trait ParallelCollectionExt: Collection {
     ///
     /// # Complexity
     ///   - O(n) where `n == self.count()`.
-    fn parallel_first_position_where<Pred>(
+    fn first_position_where_par<Pred>(
         &self,
         pred: Pred,
     ) -> Option<Self::Position>
@@ -41,14 +41,11 @@ pub trait ParallelCollectionExt: Collection {
     ///
     /// # Complexity
     ///   - O(n) where `n == self.count()`.
-    fn parallel_first_position_of(
-        &self,
-        e: &Self::Element,
-    ) -> Option<Self::Position>
+    fn first_position_of_par(&self, e: &Self::Element) -> Option<Self::Position>
     where
         Self::Element: Eq + Sync, // TODO: is Sync really necessary??
     {
-        self.parallel_first_position_where(|x| x == e)
+        self.first_position_where_par(|x| x == e)
     }
 
     /// Finds position of last element in `self` satisfying `pred`. If no such
@@ -57,7 +54,7 @@ pub trait ParallelCollectionExt: Collection {
     /// # Complexity
     ///   - O(n) where `n == self.count()`.
     /// ```
-    fn parallel_last_position_where<Pred>(
+    fn last_position_where_par<Pred>(
         &self,
         pred: Pred,
     ) -> Option<Self::Position>
@@ -86,14 +83,11 @@ pub trait ParallelCollectionExt: Collection {
     ///
     /// # Complexity
     ///   - O(n) where `n == self.count()`.
-    fn parallel_last_position_of(
-        &self,
-        e: &Self::Element,
-    ) -> Option<Self::Position>
+    fn last_position_of_par(&self, e: &Self::Element) -> Option<Self::Position>
     where
         Self::Element: Eq + Sync,
     {
-        self.parallel_last_position_where(|x| x == e)
+        self.last_position_where_par(|x| x == e)
     }
 
     /*-----------------Predicate Test Algorithms-----------------*/
@@ -102,7 +96,7 @@ pub trait ParallelCollectionExt: Collection {
     ///
     /// # Complexity
     ///   - O(n) where `n == self.count()`.
-    fn parallel_all_satisfy<Pred>(&self, pred: Pred) -> bool
+    fn all_satisfy_par<Pred>(&self, pred: Pred) -> bool
     where
         Pred: Fn(&Self::Element) -> bool + Clone + Send,
     {
@@ -127,7 +121,7 @@ pub trait ParallelCollectionExt: Collection {
     ///
     /// # Complexity
     ///   - O(n) where `n == self.count()`.
-    fn parallel_any_satisfy<Pred>(&self, pred: Pred) -> bool
+    fn any_satisfy_par<Pred>(&self, pred: Pred) -> bool
     where
         Pred: Fn(&Self::Element) -> bool + Clone + Send,
     {
@@ -152,7 +146,7 @@ pub trait ParallelCollectionExt: Collection {
     ///
     /// # Complexity
     ///   - O(n) where `n == self.count()`.
-    fn parallel_none_satisfy<Pred>(&self, pred: Pred) -> bool
+    fn none_satisfy_par<Pred>(&self, pred: Pred) -> bool
     where
         Pred: Fn(&Self::Element) -> bool + Clone + Send,
     {

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -10,7 +10,11 @@ use crate::unwrap_option_vec;
 /// Returns the global thread pool to execute tasks on.
 pub(crate) fn global_thread_pool() -> &'static rayon_core::ThreadPool {
     static POOL: LazyLock<rayon_core::ThreadPool> = LazyLock::new(|| {
+        let t = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1);
         rayon_core::ThreadPoolBuilder::new()
+            .num_threads(t)
             .build()
             .expect("failed to get global threadpool")
     });

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -1,20 +1,34 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2025 Rishabh Dwivedi (rishabhdwivedi17@gmail.com)
 
+use std::sync::LazyLock;
+
+use rayon_core::ThreadPool;
+
 use crate::unwrap_option_vec;
+
+/// Returns the global thread pool to execute tasks on.
+pub(crate) fn global_thread_pool() -> &'static rayon_core::ThreadPool {
+    static POOL: LazyLock<rayon_core::ThreadPool> = LazyLock::new(|| {
+        rayon_core::ThreadPoolBuilder::new()
+            .build()
+            .expect("failed to get global threadpool")
+    });
+    &POOL
+}
 
 /// Executes all task in `tasks` concurrently on global executor.
 ///
 /// # Postcondition
 ///   - If number of tasks is less than equal to available processors, then
 ///     tasks would execute parallely.
-pub fn exec_par_void<Task, Tasks>(mut tasks: Tasks)
+pub fn exec_par_void_on<Task, Tasks>(mut tasks: Tasks, scheduler: &ThreadPool)
 where
     Task: FnOnce() + Send,
     Tasks: Iterator<Item = Task> + Send,
 {
     if let Some(first_task) = tasks.next() {
-        rayon_core::scope(|s| {
+        scheduler.scope(|s| {
             for task in tasks {
                 s.spawn(|_| task());
             }
@@ -29,7 +43,10 @@ where
 /// # Postcondition
 ///   - If number of tasks is less than equal to available processors, then
 ///     tasks would execute parallely.
-pub fn exec_par<Task, TaskResult, Tasks>(tasks: Tasks) -> Vec<TaskResult>
+pub fn exec_par_on<Task, TaskResult, Tasks>(
+    tasks: Tasks,
+    scheduler: &ThreadPool,
+) -> Vec<TaskResult>
 where
     Task: FnOnce() -> TaskResult + Send,
     Tasks: ExactSizeIterator<Item = Task> + Send,
@@ -42,7 +59,7 @@ where
         .zip(task_results.iter_mut())
         .map(|(task, res)| move || *res = Some(task()));
 
-    exec_par_void(tasks_filling_results);
+    exec_par_void_on(tasks_filling_results, scheduler);
 
     unwrap_option_vec(task_results)
 }

--- a/tests/find_test.rs
+++ b/tests/find_test.rs
@@ -68,60 +68,60 @@ pub mod tests {
     #[test]
     fn parallel_first_position_where() {
         let arr = [5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5];
-        let i = arr.parallel_first_position_where(|x| *x == 5);
+        let i = arr.first_position_where_par(|x| *x == 5);
         assert_eq!(i, Some(0));
 
         let arr = [0, 0, 0, 0, 0, 0, 5, 5, 5, 5, 5];
-        let i = arr.parallel_first_position_where(|x| *x == 5);
+        let i = arr.first_position_where_par(|x| *x == 5);
         assert_eq!(i, Some(6));
 
         let arr = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-        let i = arr.parallel_first_position_where(|x| *x == 5);
+        let i = arr.first_position_where_par(|x| *x == 5);
         assert_eq!(i, None);
     }
 
     #[test]
     fn parallel_first_position_of() {
         let arr = [5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5];
-        let i = arr.parallel_first_position_of(&5);
+        let i = arr.first_position_of_par(&5);
         assert_eq!(i, Some(0));
 
         let arr = [0, 0, 0, 0, 0, 0, 5, 5, 5, 5, 5];
-        let i = arr.parallel_first_position_of(&5);
+        let i = arr.first_position_of_par(&5);
         assert_eq!(i, Some(6));
 
         let arr = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-        let i = arr.parallel_first_position_of(&5);
+        let i = arr.first_position_of_par(&5);
         assert_eq!(i, None);
     }
 
     #[test]
     fn parallel_last_position_where() {
         let arr = [5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5];
-        let i = arr.parallel_last_position_where(|x| *x == 5);
+        let i = arr.last_position_where_par(|x| *x == 5);
         assert_eq!(i, Some(10));
 
         let arr = [0, 0, 0, 0, 0, 0, 5, 5, 5, 5, 5];
-        let i = arr.parallel_last_position_where(|x| *x == 5);
+        let i = arr.last_position_where_par(|x| *x == 5);
         assert_eq!(i, Some(10));
 
         let arr = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-        let i = arr.parallel_last_position_where(|x| *x == 5);
+        let i = arr.last_position_where_par(|x| *x == 5);
         assert_eq!(i, None);
     }
 
     #[test]
     fn parallel_last_position_of() {
         let arr = [5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5];
-        let i = arr.parallel_last_position_of(&5);
+        let i = arr.last_position_of_par(&5);
         assert_eq!(i, Some(10));
 
         let arr = [0, 0, 0, 0, 0, 0, 5, 5, 5, 5, 5];
-        let i = arr.parallel_last_position_of(&5);
+        let i = arr.last_position_of_par(&5);
         assert_eq!(i, Some(10));
 
         let arr = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-        let i = arr.parallel_last_position_of(&5);
+        let i = arr.last_position_of_par(&5);
         assert_eq!(i, None);
     }
 }

--- a/tests/find_test.rs
+++ b/tests/find_test.rs
@@ -67,61 +67,69 @@ pub mod tests {
 
     #[test]
     fn parallel_first_position_where() {
+        let e = rayon_core::ThreadPoolBuilder::new().build().unwrap();
+
         let arr = [5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5];
-        let i = arr.first_position_where_par(|x| *x == 5);
+        let i = arr.first_position_where_par_on(&e, |x| *x == 5);
         assert_eq!(i, Some(0));
 
         let arr = [0, 0, 0, 0, 0, 0, 5, 5, 5, 5, 5];
-        let i = arr.first_position_where_par(|x| *x == 5);
+        let i = arr.first_position_where_par_on(&e, |x| *x == 5);
         assert_eq!(i, Some(6));
 
         let arr = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-        let i = arr.first_position_where_par(|x| *x == 5);
+        let i = arr.first_position_where_par_on(&e, |x| *x == 5);
         assert_eq!(i, None);
     }
 
     #[test]
     fn parallel_first_position_of() {
+        let e = rayon_core::ThreadPoolBuilder::new().build().unwrap();
+
         let arr = [5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5];
-        let i = arr.first_position_of_par(&5);
+        let i = arr.first_position_of_par_on(&e, &5);
         assert_eq!(i, Some(0));
 
         let arr = [0, 0, 0, 0, 0, 0, 5, 5, 5, 5, 5];
-        let i = arr.first_position_of_par(&5);
+        let i = arr.first_position_of_par_on(&e, &5);
         assert_eq!(i, Some(6));
 
         let arr = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-        let i = arr.first_position_of_par(&5);
+        let i = arr.first_position_of_par_on(&e, &5);
         assert_eq!(i, None);
     }
 
     #[test]
     fn parallel_last_position_where() {
+        let e = rayon_core::ThreadPoolBuilder::new().build().unwrap();
+
         let arr = [5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5];
-        let i = arr.last_position_where_par(|x| *x == 5);
+        let i = arr.last_position_where_par_on(&e, |x| *x == 5);
         assert_eq!(i, Some(10));
 
         let arr = [0, 0, 0, 0, 0, 0, 5, 5, 5, 5, 5];
-        let i = arr.last_position_where_par(|x| *x == 5);
+        let i = arr.last_position_where_par_on(&e, |x| *x == 5);
         assert_eq!(i, Some(10));
 
         let arr = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-        let i = arr.last_position_where_par(|x| *x == 5);
+        let i = arr.last_position_where_par_on(&e, |x| *x == 5);
         assert_eq!(i, None);
     }
 
     #[test]
     fn parallel_last_position_of() {
+        let e = rayon_core::ThreadPoolBuilder::new().build().unwrap();
+
         let arr = [5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5];
-        let i = arr.last_position_of_par(&5);
+        let i = arr.last_position_of_par_on(&e, &5);
         assert_eq!(i, Some(10));
 
         let arr = [0, 0, 0, 0, 0, 0, 5, 5, 5, 5, 5];
-        let i = arr.last_position_of_par(&5);
+        let i = arr.last_position_of_par_on(&e, &5);
         assert_eq!(i, Some(10));
 
         let arr = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-        let i = arr.last_position_of_par(&5);
+        let i = arr.last_position_of_par_on(&e, &5);
         assert_eq!(i, None);
     }
 }

--- a/tests/predicate_satisfy_test.rs
+++ b/tests/predicate_satisfy_test.rs
@@ -20,13 +20,13 @@ pub mod tests {
     #[test]
     fn parallel_all_satisfy() {
         let arr = [1, 3, 5];
-        assert!(arr.parallel_all_satisfy(|x| x % 2 == 1));
+        assert!(arr.all_satisfy_par(|x| x % 2 == 1));
 
         let arr = [1, 2, 5];
-        assert!(!arr.parallel_all_satisfy(|x| x % 2 == 1));
+        assert!(!arr.all_satisfy_par(|x| x % 2 == 1));
 
         let arr = [];
-        assert!(arr.parallel_all_satisfy(|x| x % 2 == 1));
+        assert!(arr.all_satisfy_par(|x| x % 2 == 1));
     }
 
     #[test]
@@ -44,13 +44,13 @@ pub mod tests {
     #[test]
     fn parallel_any_satisfy() {
         let arr = [1, 2, 5];
-        assert!(arr.parallel_any_satisfy(|x| x % 2 == 1));
+        assert!(arr.any_satisfy_par(|x| x % 2 == 1));
 
         let arr = [2, 4, 6];
-        assert!(!arr.parallel_any_satisfy(|x| x % 2 == 1));
+        assert!(!arr.any_satisfy_par(|x| x % 2 == 1));
 
         let arr = [];
-        assert!(!arr.parallel_any_satisfy(|x| x % 2 == 1));
+        assert!(!arr.any_satisfy_par(|x| x % 2 == 1));
     }
 
     #[test]
@@ -68,12 +68,12 @@ pub mod tests {
     #[test]
     fn parallel_none_satisfy() {
         let arr = [2, 4, 6];
-        assert!(arr.parallel_none_satisfy(|x| x % 2 == 1));
+        assert!(arr.none_satisfy_par(|x| x % 2 == 1));
 
         let arr = [2, 1, 6];
-        assert!(!arr.parallel_none_satisfy(|x| x % 2 == 1));
+        assert!(!arr.none_satisfy_par(|x| x % 2 == 1));
 
         let arr = [];
-        assert!(arr.parallel_none_satisfy(|x| x % 2 == 1));
+        assert!(arr.none_satisfy_par(|x| x % 2 == 1));
     }
 }

--- a/tests/predicate_satisfy_test.rs
+++ b/tests/predicate_satisfy_test.rs
@@ -19,14 +19,16 @@ pub mod tests {
 
     #[test]
     fn parallel_all_satisfy() {
+        let e = rayon_core::ThreadPoolBuilder::new().build().unwrap();
+
         let arr = [1, 3, 5];
-        assert!(arr.all_satisfy_par(|x| x % 2 == 1));
+        assert!(arr.all_satisfy_par_on(&e, |x| x % 2 == 1));
 
         let arr = [1, 2, 5];
-        assert!(!arr.all_satisfy_par(|x| x % 2 == 1));
+        assert!(!arr.all_satisfy_par_on(&e, |x| x % 2 == 1));
 
         let arr = [];
-        assert!(arr.all_satisfy_par(|x| x % 2 == 1));
+        assert!(arr.all_satisfy_par_on(&e, |x| x % 2 == 1));
     }
 
     #[test]
@@ -43,14 +45,16 @@ pub mod tests {
 
     #[test]
     fn parallel_any_satisfy() {
+        let e = rayon_core::ThreadPoolBuilder::new().build().unwrap();
+
         let arr = [1, 2, 5];
-        assert!(arr.any_satisfy_par(|x| x % 2 == 1));
+        assert!(arr.any_satisfy_par_on(&e, |x| x % 2 == 1));
 
         let arr = [2, 4, 6];
-        assert!(!arr.any_satisfy_par(|x| x % 2 == 1));
+        assert!(!arr.any_satisfy_par_on(&e, |x| x % 2 == 1));
 
         let arr = [];
-        assert!(!arr.any_satisfy_par(|x| x % 2 == 1));
+        assert!(!arr.any_satisfy_par_on(&e, |x| x % 2 == 1));
     }
 
     #[test]
@@ -67,13 +71,15 @@ pub mod tests {
 
     #[test]
     fn parallel_none_satisfy() {
+        let e = rayon_core::ThreadPoolBuilder::new().build().unwrap();
+
         let arr = [2, 4, 6];
-        assert!(arr.none_satisfy_par(|x| x % 2 == 1));
+        assert!(arr.none_satisfy_par_on(&e, |x| x % 2 == 1));
 
         let arr = [2, 1, 6];
-        assert!(!arr.none_satisfy_par(|x| x % 2 == 1));
+        assert!(!arr.none_satisfy_par_on(&e, |x| x % 2 == 1));
 
         let arr = [];
-        assert!(arr.none_satisfy_par(|x| x % 2 == 1));
+        assert!(arr.none_satisfy_par_on(&e, |x| x % 2 == 1));
     }
 }


### PR DESCRIPTION
### Root Cause
Rayon threads doesn't end at all and would be cleaned when program closes. Then miri treat is as leak of resources.

### Fix
To fix the same, provided the variant of algorithms that can run on any custom thread pool and instead of testing the algorithms for global thread pool, simply tested the algorithms with local scope based thread pool. Thus, when scope ends, threads are destroyed.

### Future work
Provide a custom scheduler trait, so that can support scheduling algorithms on any custom scheduler satisfying scheduler.